### PR TITLE
Upload mustache.java to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,29 @@
   <packaging>jar</packaging>
 
   <name>mustache.java</name>
-  <url>http://maven.apache.org</url>
+  <description>Implementation of mustache.js for Java</description>
+  <url>http://github.com/spullara/mustache.java</url>
+
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/spullara/mustache.java.git</connection>
+    <url>http://github.com/spullara/mustache.java</url>
+  </scm>
+
+  <developers>
+    <developer>
+      <name>Sam Pullara</name>
+      <email>sam@sampullara.com</email>
+      <url>http://www.javarants.com</url>
+    </developer>
+  </developers>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
I think it would be a good idea to upload mustache.java to Maven Central. I realise that it is already available in another repository, but many people don't like to rely on third party repositories, including me :)

I helped several projects upload their artifacts to Maven Central and I'd be happy to help with this one too, if you're interested.

In this pull request, I've modified your POM according to [Maven Central's requirements](https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide), that's the first step.

With these changes, the artifacts can be [uploaded to the OSS Nexus](https://docs.sonatype.org/display/Repository/Central+Sync+Requirements), it comes down to this:
- Get an account with their [issue tracker](https://issues.sonatype.org/browse/OSSRH).
- Create a ticket to request a new repository (and sync) for mustache.java.
- Create a GPG key - unless you have one already - and sign your artifacts (the pom, the jar, a javadoc jar and a source jar).
- Upload all artifacts and signatures (e.g. zipped together in a bundle) to the OSS Nexus (you can login with your issue tracker account).

As mentioned earlier, I'd be happy to help with that.
