### PR TITLE
When partialExtention is empty, no period should be appended

### DIFF
--- a/core/src/main/java/com/sampullara/mustache/Mustache.java
+++ b/core/src/main/java/com/sampullara/mustache/Mustache.java
@@ -418,7 +418,9 @@ public class Mustache {
       event = MustacheTrace.addEvent("compile partial: " + name, "");
     }
     Mustache mustache;
-    mustache = mj.parseFile(name + "." + getPartialExtension());
+    String partialExtension = getPartialExtension();
+    String partialName = "".equals(partialExtension) ? name : name + "." + partialExtension;
+    mustache = mj.parseFile(partialName);
     mustache.setMustacheJava(mj);
     if (trace) {
       event.end();


### PR DESCRIPTION
I'm writing some code using a custom MustacheContext to load templates from a database, in this case the template name is not a filename, so has no extension.

When using partial include of "test", mustache.java currently always appends the . so it looks up "test." when calling into MustacheContext.getReader().
