### PR TITLE
Fix bad Arrays import in DefaultCode

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/codes/DefaultCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/DefaultCode.java
@@ -2,6 +2,7 @@ package com.github.mustachejava.codes;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Logger;
@@ -14,7 +15,6 @@ import com.github.mustachejava.TemplateContext;
 import com.github.mustachejava.reflect.MissingWrapper;
 import com.github.mustachejava.util.GuardException;
 import com.github.mustachejava.util.Wrapper;
-import scala.actors.threadpool.Arrays;
 
 /**
  * Simplest possible code implementaion with some default shared behavior


### PR DESCRIPTION
DefaultCode imports scala.actors.threadpool.Arrays instead of java.util.Arrays, I'm assuming do to an IDE auto-import snafu.
