### PR TITLE
Fix bug causing (Hash)Maps with explicitly set nulls to fail

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/reflect/MissingWrapper.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/MissingWrapper.java
@@ -1,7 +1,5 @@
 package com.github.mustachejava.reflect;
 
-import java.util.List;
-
 import com.google.common.base.Predicate;
 
 /**

--- a/compiler/src/main/java/com/github/mustachejava/reflect/ReflectionObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/ReflectionObjectHandler.java
@@ -95,7 +95,7 @@ public class ReflectionObjectHandler implements ObjectHandler {
     if (scope == null) return null;
     if (scope instanceof Map) {
       Map map = (Map) scope;
-      if (map.get(name) == null) {
+      if (!map.containsKey(name)) {
         guards.add(new MapGuard(scopeIndex, name, false, wrappers));
         return null;
       } else {

--- a/compiler/src/test/java/com/github/mustachejava/ExplicitMapNullTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/ExplicitMapNullTest.java
@@ -1,0 +1,41 @@
+package com.github.mustachejava;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExplicitMapNullTest {
+
+    private static final String TEMPLATE = "{{nullData}}";
+    
+    private Mustache mustache;
+    
+    @Before
+    public void setUp() {
+        MustacheFactory factory = new DefaultMustacheFactory();
+        Reader reader = new StringReader(TEMPLATE);
+        mustache = factory.compile(reader, "template");
+    }
+    
+
+    @Test
+    public void textExplicitNullMapValue() {
+        Map<String, Object> model = new HashMap<String, Object>();
+        model.put("nullData", null);
+        
+        StringWriter writer = new StringWriter();
+        mustache.execute(writer, model);
+        
+        assertEquals("", writer.toString());
+    }
+    
+    
+    
+}


### PR DESCRIPTION
ReflectionObjectHandler checked map value presence by comparing the result of map.get(name) to null. MapGuard checks for map.containsKey(name). If a value is set to null with map.put(name, null), the ReflectionObjectHandler test creates a MapGuard with contains = false, but when the guard is evaluated, it fails because map.containsKey(name) returns true.

This should fix it.
