### PR TITLE
Fix problems with dot notation misses on last element in path

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/reflect/ReflectionObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/ReflectionObjectHandler.java
@@ -76,9 +76,8 @@ public class ReflectionObjectHandler implements ObjectHandler {
       }
       Wrapper[] foundWrappers = wrappers == null ? null : wrappers.toArray(
               new Wrapper[wrappers.size()]);
-      Wrapper foundWrapper = findWrapper(i, foundWrappers, guards, scope, subname);
-      if (foundWrapper != null) {
-        wrapper = foundWrapper;
+      wrapper = findWrapper(i, foundWrappers, guards, scope, subname);
+      if (wrapper != null) {
         break;
       }
     }

--- a/compiler/src/test/java/com/github/mustachejava/DotNotationTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/DotNotationTest.java
@@ -1,56 +1,77 @@
 package com.github.mustachejava;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import java.io.*;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class DotNotationTest {
 
-  private static final String TEMPLATE = "{{container1.container2.target}}";
+  private static final String EARLY_MISS_TEMPLATE = "{{container1.container2.target}}";
+  private static final String LAST_ELEMENT_MISS_TEMPLATE = "{{container1.nothing}}";
   
   private static final class ModelObject {
+      @SuppressWarnings("unused")
       public Object getContainer2() {
           return null;
       }
   }
   
-  private Mustache mustache;
+  private MustacheFactory factory;
+  private Map<String, Object> mapModel;
+  private Map<String, Object> objectModel;
   
   @Before
   public void setUp() {
-      MustacheFactory factory = new DefaultMustacheFactory();
-      Reader reader = new StringReader(TEMPLATE);
-      mustache = factory.compile(reader, "template");
+      factory = new DefaultMustacheFactory();
+      
+      mapModel = new HashMap<String, Object>();
+      Map<String, Object> container1 = new HashMap<String, Object>();
+      mapModel.put("container1", container1);
+      
+      objectModel = new HashMap<String, Object>();
+      objectModel.put("container1", new ModelObject());
   }
   
 
   @Test
   public void testIncompleteMapPath() {
-      Map<String, Object> model = new HashMap<String, Object>();
-      Map<String, Object> container1 = new HashMap<String, Object>();
-      model.put("container1", container1);
-      StringWriter writer = new StringWriter();
-      mustache.execute(writer, model);
-      
-      assertEquals("", writer.toString());
+      testMiss(mapModel, EARLY_MISS_TEMPLATE);
+  }
+  
+  @Test
+  public void testAlmostCompleteMapPath() {
+      testMiss(mapModel, LAST_ELEMENT_MISS_TEMPLATE);
+  }
+  
+  @Test
+  public void testIncompleteObjectPath() {
+      testMiss(objectModel, EARLY_MISS_TEMPLATE);
   }
 
   @Test
-  public void testIncompleteObjectPath() {
-      Map<String, Object> model = new HashMap<String, Object>();
-      Object container1 = new ModelObject();
-      model.put("container1", container1);
+  public void testAlmostCompleteObjectPath() {
+      testMiss(objectModel, LAST_ELEMENT_MISS_TEMPLATE);
+  }
+  
+  private void testMiss(Object model, String template) {
+      Mustache mustache = compile(template);
       StringWriter writer = new StringWriter();
       mustache.execute(writer, model);
       
       assertEquals("", writer.toString());
   }
 
+  private Mustache compile(String template) {
+      Reader reader = new StringReader(template);
+      return factory.compile(reader, "template");
+  }
+      
+  
 }


### PR DESCRIPTION
Got another one. This time it's due to dot-notation misses on the last element in the path. ReflectionObjectHandler.findWrapper was returning null on name lookup misses, but the find method didn't set it's current wrapper to null when that happened, it just tried to check the next object in the scope chain. If there was no next object, find's for loop ended, and it would return the bogus wrapper for the next-to-last object in the chain, potentially causing some pretty funky behavior.
