### PR TITLE
Make GPG plugin run only when build is triggerd by release plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,19 +68,36 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
+
+    <profiles>
+    <profile>
+      <id>release-sign-artifacts</id>
+        <activation>
+          <property>
+            <name>performRelease</name>
+            <value>true</value>
+          </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.4</version>
+                  <executions>
+                    <execution>
+                      <id>sign-artifacts</id>
+                      <phase>verify</phase>
+                      <goals>
+                        <goal>sign</goal>
+                      </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
It's kind of a hassle when doing development & testing to have the GPG plugin running on every build, particularly if you're working on a machine that doesn't have GPG configured. By putting it in a profile, it can be set up so it only runs when doing a release with the maven-release-plugin. If there are specific reasons to run it on every build, feel free to ignore this pull request.
