### PR TITLE
Make object -> string conversion extendable

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/ObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/ObjectHandler.java
@@ -53,4 +53,12 @@ public interface ObjectHandler {
    * @return
    */
   Binding createBinding(String name, TemplateContext tc, Code code);
+  
+  /**
+   * Turns an object into the string representation that should be displayed
+   * in templates.
+   * @param object the object to be displayed
+   * @return a string representation of the object.
+   */
+  String stringify(Object object);
 }

--- a/compiler/src/main/java/com/github/mustachejava/codes/ValueCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/ValueCode.java
@@ -57,7 +57,7 @@ public class ValueCode extends DefaultCode {
         } else if (object instanceof Callable) {
           return handleCallable(writer, (Callable) object, scopes);
         } else {
-          execute(writer, stringify(object));
+          execute(writer, oh.stringify(object));
         }
       } catch (Exception e) {
         throw new MustacheException("Failed to get value for " + name + " at line " + tc.file() + ":" + tc.line(), e);
@@ -68,7 +68,7 @@ public class ValueCode extends DefaultCode {
 
   protected Writer handleCallable(Writer writer, final Callable callable, final Object[] scopes) throws Exception {
     if (les == null) {
-      execute(writer, stringify(callable.call()));
+      execute(writer, oh.stringify(callable.call()));
       return super.execute(writer, scopes);
     } else {
       // Flush the current writer
@@ -84,7 +84,7 @@ public class ValueCode extends DefaultCode {
         public void run() {
           try {
             Object call = callable.call();
-            execute(finalWriter, call == null ? null : stringify(call));
+            execute(finalWriter, call == null ? null : oh.stringify(call));
             latchedWriter.done();
           } catch (Throwable e) {
             latchedWriter.failed(e);
@@ -124,15 +124,4 @@ public class ValueCode extends DefaultCode {
     }
   }
   
-  /**
-   * This method can be overridden by subclasses if they wish to customize
-   * the way in which objects are converted to strings for display, for
-   * example by automatically localizing numbers & dates.
-   * 
-   * @param object the object to convert to a string
-   * @return a string representation of the object
-   */
-  protected String stringify(Object object) {
-    return object.toString();
-  }
 }

--- a/compiler/src/main/java/com/github/mustachejava/reflect/ReflectionObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/ReflectionObjectHandler.java
@@ -131,4 +131,9 @@ public class ReflectionObjectHandler extends BaseObjectHandler {
   public Binding createBinding(String name, TemplateContext tc, Code code) {
     return new GuardedBinding(this, name, tc, code);
   }
+
+  @Override
+  public String stringify(Object object) {
+    return object.toString();
+  }
 }

--- a/compiler/src/main/java/com/github/mustachejava/reflect/SimpleObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/SimpleObjectHandler.java
@@ -128,4 +128,9 @@ public class SimpleObjectHandler extends BaseObjectHandler {
     }
     return ao == NONE ? null : ao;
   }
+
+  @Override
+  public String stringify(Object object) {
+    return object.toString();
+  }
 }


### PR DESCRIPTION
This is a small tweak that would allow extensions to valueCode that alter the way objects are converted to strings when directly displayed on the page.

For us this is useful because Spring has out-of-the-box mechanisms for converting objects to localized string versions and vice-versa. Our code becomes much simpler when we can rely on this conversion when rendering the templates rather than having to manually inject and call the formatting tools in every controller or viewmodel.
