### PR TITLE
Optionally support access to non get(key) methods on instances of Map

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/ObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/ObjectHandler.java
@@ -1,8 +1,9 @@
 package com.github.mustachejava;
 
-import com.github.mustachejava.util.Wrapper;
-
 import java.io.Writer;
+import java.util.Map;
+
+import com.github.mustachejava.util.Wrapper;
 
 /**
  * The ObjectHandler is responsible for creating wrappers to find values
@@ -54,19 +55,4 @@ public interface ObjectHandler {
    */
   Binding createBinding(String name, TemplateContext tc, Code code);
   
-  /**
-   * Sets whether or not {@link Map} methods other than get(key) are
-   * accessible to templates.
-   * @param mapMethodsAccessible true if methods other than get(key) should
-   * be accessible, false otherwise.
-   */
-  void setMapMethodsAccessible(boolean mapMethodsAccessible);
-  
-  /**
-   * Indicates whether or not methods other than get(key) are accessible in
-   * templates
-   * @return true of methods other than get(key) will be resolved, false
-   * otherwise
-   */
-  boolean isMapMethodsAccessible();
 }

--- a/compiler/src/main/java/com/github/mustachejava/reflect/ReflectionObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/ReflectionObjectHandler.java
@@ -44,8 +44,6 @@ public class ReflectionObjectHandler extends BaseObjectHandler {
     }
   }
   
-  private boolean mapMethodsAccessible;
-
   @SuppressWarnings("unchecked")
   @Override
   public Wrapper find(String name, final Object[] scopes) {
@@ -115,9 +113,11 @@ public class ReflectionObjectHandler extends BaseObjectHandler {
       if (map.containsKey(name)) {
         guards.add(new MapGuard(this, scopeIndex, name, true, wrappers));
         return createWrapper(scopeIndex, wrappers, guards, MAP_METHOD, new Object[]{name});
-      } else if (!mapMethodsAccessible) {
+      } else {
         guards.add(new MapGuard(this, scopeIndex, name, false, wrappers));
-        return null;
+        if (!areMethodsAccessible(map)) {
+          return null;
+        }
       }
     }
     AccessibleObject member = findMember(scope.getClass(), name);
@@ -134,13 +134,9 @@ public class ReflectionObjectHandler extends BaseObjectHandler {
     return new GuardedBinding(this, name, tc, code);
   }
 
-  @Override
-  public void setMapMethodsAccessible(boolean mapMethodsAccessible) {
-    this.mapMethodsAccessible = mapMethodsAccessible;
+  protected boolean areMethodsAccessible(Map<?, ?> map) {
+    return false;
   }
 
-  @Override
-  public boolean isMapMethodsAccessible() {
-    return mapMethodsAccessible;
-  }
+  
 }

--- a/compiler/src/main/java/com/github/mustachejava/reflect/SimpleObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/SimpleObjectHandler.java
@@ -16,8 +16,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class SimpleObjectHandler extends BaseObjectHandler {
 
-  private boolean mapMethodsAccessible;
-  
   @Override
   public Binding createBinding(final String name, TemplateContext tc, Code code) {
     return new Binding() {
@@ -46,7 +44,7 @@ public class SimpleObjectHandler extends BaseObjectHandler {
                 Map map = (Map) scope;
                 if (map.containsKey(name)) {
                   return map.get(name);
-                } else if (!mapMethodsAccessible) {
+                } else if (!areMethodsAccessible(map)) {
                   continue; //don't check methods, move to next scope
                 }
               }
@@ -133,13 +131,7 @@ public class SimpleObjectHandler extends BaseObjectHandler {
     return ao == NONE ? null : ao;
   }
 
-  @Override
-  public void setMapMethodsAccessible(boolean mapMethodsAccessible) {
-    this.mapMethodsAccessible = mapMethodsAccessible;
-  }
-
-  @Override
-  public boolean isMapMethodsAccessible() {
-    return mapMethodsAccessible;
+  protected boolean areMethodsAccessible(Map<?, ?> map) {
+    return false;
   }
 }


### PR DESCRIPTION
This allows for access to methods other than get(key) on classes that implement Map. The feature is off by default, but can by activated by setting an option on ObjectHandler.

The only thing that I don't like about this is that if you access an instance of Map and fall back to a method, but later use the same template with a different Map containing a matching key, the method call will be used first due to the wrapper caching (I think). However, it's a corner case, and  I don't see a solution for it other than moving wrapper caching into the ObjectHandler or some similar refactoring.
