### PR TITLE
Corrected encoding bug for File resources.

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
@@ -8,7 +8,6 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import java.io.*;
-import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -69,14 +68,16 @@ public class DefaultMustacheFactory implements MustacheFactory {
       File file = fileRoot == null ? new File(resourceName) : new File(fileRoot, resourceName);
       if (file.exists() && file.isFile()) {
         try {
-          return new BufferedReader(new FileReader(file));
+          is = new FileInputStream(file);
         } catch (FileNotFoundException e) {
           throw new MustacheException("Found file, could not open: " + file, e);
         }
       }
-      throw new MustacheException("Template " + resourceName + " not found");
+    }
+    if (is == null) {
+      throw new MustacheException("Template '" + resourceName + "' not found");
     } else {
-      return new BufferedReader(new InputStreamReader(is, Charset.forName("utf-8")));
+      return new BufferedReader(new InputStreamReader(is, "UTF-8"));
     }
   }
 


### PR DESCRIPTION
I stumbled upon a charset encoding problem when using File resources.

The problem happened when the system default charset encoding was not same as the charset from the file (UTF-8). The problem lies in the `FileReader` class and Java documentation it states that `FileInputStream` with `InputStreamReader` should be used instead (http://docs.oracle.com/javase/6/docs/api/java/io/FileReader.html).
