### PR TITLE
Remove unnecessary variable.

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/reflect/GuardedWrapper.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/GuardedWrapper.java
@@ -13,8 +13,6 @@ public class GuardedWrapper implements Wrapper {
   // and don't reallocate it.
   protected static final GuardException guardException = new GuardException();
 
-  private static boolean compile = Boolean.getBoolean("mustache.compile");
-
   static {
     guardException.setStackTrace(new StackTraceElement[0]);
   }


### PR DESCRIPTION
This prevented it from being used in the applet, where access to system properties is privileged.
