### PR TITLE
Fix for scala streams

### DIFF
--- a/compiler/src/main/scala/com/twitter/mustache/ScalaObjectHandler.scala
+++ b/compiler/src/main/scala/com/twitter/mustache/ScalaObjectHandler.scala
@@ -19,7 +19,7 @@ class ScalaObjectHandler extends ReflectionObjectHandler {
 
   override def coerce(value: Object) = {
     value match {
-      case m: Map[_, _] => asJavaMap(m)
+      case m: collection.Map[_, _] => asJavaMap(m)
       case u: BoxedUnit => null
       case o: Option[_] => o match {
         case Some(some: Object) => coerce(some)
@@ -33,7 +33,7 @@ class ScalaObjectHandler extends ReflectionObjectHandler {
     value match {
       case t: Traversable[AnyRef] => {
         var newWriter = writer
-        t map {
+        t foreach {
           next =>
             newWriter = iteration.next(newWriter, coerce(next), scopes)
         }

--- a/compiler/src/main/scala/com/twitter/mustache/TwitterObjectHandler.scala
+++ b/compiler/src/main/scala/com/twitter/mustache/TwitterObjectHandler.scala
@@ -1,29 +1,12 @@
 package com.twitter.mustache
 
-import com.github.mustachejava.Iteration
-import com.github.mustachejava.reflect.ReflectionObjectHandler
 import com.twitter.util.Future
-import java.io.Writer
-import java.lang.reflect.{Method, Field}
 import java.util.concurrent.Callable
-import scala.collection.JavaConversions.asJavaMap
-import runtime.BoxedUnit
 
-class TwitterObjectHandler extends ReflectionObjectHandler {
-
-  // Allow any method or field
-  override def checkMethod(member: Method) {}
-
-  override def checkField(member: Field) {}
+class TwitterObjectHandler extends ScalaObjectHandler {
 
   override def coerce(value: Object) = {
     value match {
-      case m: Map[_, _] => asJavaMap(m)
-      case u: BoxedUnit => null
-      case o: Option[_] => o match {
-        case Some(some: Object) => coerce(some)
-        case None => null
-      }
       case f: Future[_] => {
         new Callable[Any]() {
           def call() = {
@@ -32,36 +15,7 @@ class TwitterObjectHandler extends ReflectionObjectHandler {
           }
         }
       }
-      case _ => value
-    }
-  }
-
-  override def iterate(iteration: Iteration, writer: Writer, value: Object, scopes: Array[Object]) = {
-    value match {
-      case t: Traversable[AnyRef] => {
-        var newWriter = writer
-        t map {
-          next =>
-            newWriter = iteration.next(newWriter, coerce(next), scopes)
-        }
-        newWriter
-      }
-      case n: Number => if (n == 0) writer else iteration.next(writer, coerce(value), scopes)
-      case _ => super.iterate(iteration, writer, value, scopes)
-    }
-  }
-
-  override def falsey(iteration: Iteration, writer: Writer, value: Object, scopes: Array[Object]) = {
-    value match {
-      case t: Traversable[AnyRef] => {
-        if (t.isEmpty) {
-          iteration.next(writer, value, scopes)
-        } else {
-          writer
-        }
-      }
-      case n: Number => if (n == 0) iteration.next(writer, coerce(value), scopes) else writer
-      case _ => super.falsey(iteration, writer, value, scopes)
+      case _ => super.coerce(value)
     }
   }
 }

--- a/compiler/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
+++ b/compiler/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
@@ -81,6 +81,23 @@ class ObjectHandlerTest {
   }
 
   @Test
+  def testScalaStream() {
+    val pool = Executors.newCachedThreadPool()
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    mf.setExecutorService(pool)
+    val m = mf.compile(new StringReader("{{#stream}}{{value}}{{/stream}}"), "helloworld")
+    val sw = new StringWriter
+    val writer = m.execute(sw, new {
+      val stream = Stream(
+        new { val value = "hello" },
+        new { val value = "world" })
+    })
+    writer.close()
+    Assert.assertEquals("helloworld", sw.toString)
+  }
+
+  @Test
   def testUnit() {
     val mf = new DefaultMustacheFactory()
     mf.setObjectHandler(new TwitterObjectHandler)


### PR DESCRIPTION
ScalaObjectHandler.scala:
coerce: match collection.Map (so matches mutable.Map)
  iterate: do foreach on Traversable, not map.  If the Traversable was a Stream,
    it was lazily evalutated, so there was no guarantee any elements were included.
TwitterObjectHandler.scala:
  Refactor to derive from ScalaObjectHandler
