### PR TITLE
BundleFunctions Factory

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/functions/BundleFunctions.java
+++ b/compiler/src/main/java/com/github/mustachejava/functions/BundleFunctions.java
@@ -1,0 +1,189 @@
+package com.github.mustachejava.functions;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import com.github.mustachejava.TemplateFunction;
+import com.google.common.base.Function;
+
+/**
+ * Factory for Mustache.java translation functions based on localized Resource bundles.
+ *
+ * Example with a class:
+ * <pre>
+ * public class ... {
+ *     Function trans = BundleFunctions.newPreTranslate("com.project.locale", Locale.US);
+ *     ...
+ * }
+ * </pre>
+ *
+ * Example with a map:
+ * <pre>
+ * Map<String, Object> scopes =  new HashMap<String, Object>();
+ * scopes.put("trans", BundleFunctions.newPostTranslateNullableLabel("com.project.locale", Locale.US);
+ * ...
+ * </pre>
+ *
+ * Usage in template:
+ * {@code {{#trans}}TranslatedLabel1{{/trans}}}
+ *
+ * @author R.A. Porter
+ */
+public class BundleFunctions {
+  private static abstract class BundleFunc {
+    protected final ResourceBundle res;
+    protected final boolean returnLabels;
+
+    protected BundleFunc(String bundle, Locale locale, boolean returnLabels) {
+      this.res = ResourceBundle.getBundle(bundle, locale);
+      this.returnLabels = returnLabels;
+    }
+
+    final protected String lookup(String key) {
+      if (res.containsKey(key)) {
+        return res.getString(key);  // return translation
+      } else {
+        return returnLabels ? key : null;
+      }
+    }
+  }
+
+  static class PreTranslateFunc extends BundleFunc implements TemplateFunction {
+    private PreTranslateFunc(String bundle, Locale locale, boolean returnLabels) {
+      super(bundle, locale, returnLabels);
+    }
+
+    @Override
+    public String apply(String input) {
+      return super.lookup(input);
+    }
+  }
+
+  static class PostTranslateFunc extends BundleFunc implements Function {
+    private PostTranslateFunc(String bundle, Locale locale, boolean returnLabels) {
+      super(bundle, locale, returnLabels);
+    }
+
+    @Override
+    public Object apply(Object input) {
+      return super.lookup((String) input);
+    }
+  }
+
+  /**
+   * Returns a Function that operates prior to template evaluation and returns unknown keys intact.
+   * <p/>
+   * Given the following HTML:
+   * <pre>
+   * {{#trans}}Label1{{/trans}}
+   * {{#trans}}Label.unknown{{/trans}}
+   * {{#trans}}Label.{{replaceMe}}{{/trans}}
+   * </pre>
+   * and the following properties in the provided bundle:
+   * <pre>
+   * Label1=hello
+   * Label.replaced=world
+   * </pre>
+   * and a mapping from {@code replaceMe} to the value {@code replaced}, the following output
+   * will be generated:
+   * <pre>
+   * hello
+   * Label.unknown
+   * Label.replaced
+   * </pre>
+   *
+   * @param bundle name of the resource bundle
+   * @param locale translation locale
+   * @return Function that operates prior to template evaluation and returns unknown keys intact
+   */
+  public static Function newPreTranslate(String bundle, Locale locale) {
+    return new PreTranslateFunc(bundle, locale, true);
+  }
+
+  /**
+   * Returns a Function that operates prior to template evaluation and returns nulls for unknown keys.
+   * <p/>
+   * Given the following HTML:
+   * <pre>
+   * {{#trans}}Label1{{/trans}}
+   * {{#trans}}Label.unknown{{/trans}}
+   * {{#trans}}Label.{{replaceMe}}{{/trans}}
+   * </pre>
+   * and the following properties in the provided bundle:
+   * <pre>
+   * Label1=hello
+   * Label.replaced=world
+   * </pre>
+   * and a mapping from {@code replaceMe} to the value {@code replaced}, the following output
+   * will be generated:
+   * <pre>
+   * hello
+   * </pre>
+   *
+   * @param bundle name of the resource bundle
+   * @param locale translation locale
+   * @return Function that operates prior to template evaluation and returns nulls for unknown keys
+   */
+  public static Function newPreTranslateNullableLabel(String bundle, Locale locale) {
+    return new PreTranslateFunc(bundle, locale, false);
+  }
+
+  /**
+   * Returns a Function that operates after template evaluation and returns unknown keys intact.
+   * <p/>
+   * Given the following HTML:
+   * <pre>
+   * {{#trans}}Label1{{/trans}}
+   * {{#trans}}Label.unknown{{/trans}}
+   * {{#trans}}Label.{{replaceMe}}{{/trans}}
+   * </pre>
+   * and the following properties in the provided bundle:
+   * <pre>
+   * Label1=hello
+   * Label.replaced=world
+   * </pre>
+   * and a mapping from {@code replaceMe} to the value {@code replaced}, the following output
+   * will be generated:
+   * <pre>
+   * hello
+   * Label.unknown
+   * world
+   * </pre>
+   *
+   * @param bundle name of the resource bundle
+   * @param locale translation locale
+   * @return Function that operates after template evaluation and returns unknown keys intact
+   */
+  public static Function newPostTranslate(String bundle, Locale locale) {
+    return new PostTranslateFunc(bundle, locale, true);
+  }
+
+  /**
+   * Returns a Function that operates after template evaluation and returns nulls for unknown keys.
+   * <p/>
+   * Given the following HTML:
+   * <pre>
+   * {{#trans}}Label1{{/trans}}
+   * {{#trans}}Label.unknown{{/trans}}
+   * {{#trans}}Label.{{replaceMe}}{{/trans}}
+   * </pre>
+   * and the following properties in the provided bundle:
+   * <pre>
+   * Label1=hello
+   * Label.replaced=world
+   * </pre>
+   * and a mapping from {@code replaceMe} to the value {@code replaced}, the following output
+   * will be generated:
+   * <pre>
+   * hello
+   * world
+   * </pre>
+   *
+   * @param bundle name of the resource bundle
+   * @param locale translation locale
+   * @return Function that operates after template evaluation and returns nulls for unknown keys
+   */
+  public static Function newPostTranslateNullableLabel(String bundle, Locale locale) {
+    return new PostTranslateFunc(bundle, locale, false);
+  }
+}

--- a/compiler/src/main/java/com/github/mustachejava/functions/TranslateBundleFunction.java
+++ b/compiler/src/main/java/com/github/mustachejava/functions/TranslateBundleFunction.java
@@ -33,7 +33,7 @@ public class TranslateBundleFunction implements TemplateFunction {
 	 * @param bundle resource bundle name
 	 * @param locale translation locale
 	 */
-	TranslateBundleFunction(String bundle, Locale locale) {
+	public TranslateBundleFunction(String bundle, Locale locale) {
 		this.res = ResourceBundle.getBundle(bundle, locale);
 	}
 	

--- a/compiler/src/test/java/com/github/mustachejava/functions/BundleFunctionsTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/functions/BundleFunctionsTest.java
@@ -1,0 +1,92 @@
+package com.github.mustachejava.functions;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheException;
+import com.github.mustachejava.MustacheFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.*;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * @author R.A. Porter
+ * @version 1.0
+ * @since 1/17/13
+ */
+public class BundleFunctionsTest {
+    private static File root;
+    private static final String BUNDLE = "com.github.mustachejava.functions.translatebundle";
+
+    @Test
+    public void testPreLabels() throws MustacheException, IOException, ExecutionException, InterruptedException {
+        MustacheFactory c = new DefaultMustacheFactory(root);
+        Mustache m = c.compile("bundles.html");
+        StringWriter sw = new StringWriter();
+        Map<String, Object> scope = new HashMap<String, Object>();
+        scope.put("trans", BundleFunctions.newPreTranslate(BUNDLE, Locale.US));
+        scope.put("replaceMe", "replaced");
+        m.execute(sw, scope);
+        assertEquals(getContents(root, "bundles_pre_labels.txt"), sw.toString());
+    }
+
+    @Test
+    public void testPostLabels() throws MustacheException, IOException, ExecutionException, InterruptedException {
+        MustacheFactory c = new DefaultMustacheFactory(root);
+        Mustache m = c.compile("bundles.html");
+        StringWriter sw = new StringWriter();
+        Map<String, Object> scope = new HashMap<String, Object>();
+        scope.put("trans", BundleFunctions.newPostTranslate(BUNDLE, Locale.US));
+        scope.put("replaceMe", "replaced");
+        m.execute(sw, scope);
+        assertEquals(getContents(root, "bundles_post_labels.txt"), sw.toString());
+    }
+
+    @Test
+    public void testPreNullLabels() throws MustacheException, IOException, ExecutionException, InterruptedException {
+        MustacheFactory c = new DefaultMustacheFactory(root);
+        Mustache m = c.compile("bundles.html");
+        StringWriter sw = new StringWriter();
+        Map<String, Object> scope = new HashMap<String, Object>();
+        scope.put("trans", BundleFunctions.newPreTranslateNullableLabel(BUNDLE, Locale.US));
+        scope.put("replaceMe", "replaced");
+        m.execute(sw, scope);
+        assertEquals(getContents(root, "bundles_nulllabels.txt"), sw.toString());
+    }
+
+    @Test
+    public void testPostNullLabels() throws MustacheException, IOException, ExecutionException, InterruptedException {
+        MustacheFactory c = new DefaultMustacheFactory(root);
+        Mustache m = c.compile("bundles.html");
+        StringWriter sw = new StringWriter();
+        Map<String, Object> scope = new HashMap<String, Object>();
+        scope.put("trans", BundleFunctions.newPostTranslateNullableLabel(BUNDLE, Locale.US));
+        // Intentionally leave off the replacement value
+        m.execute(sw, scope);
+        assertEquals(getContents(root, "bundles_nulllabels.txt"), sw.toString());
+    }
+
+    protected String getContents(File root, String file) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(new File(root, file)),"UTF-8"));
+        StringWriter capture = new StringWriter();
+        char[] buffer = new char[8192];
+        int read;
+        while ((read = br.read(buffer)) != -1) {
+            capture.write(buffer, 0, read);
+        }
+        return capture.toString();
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        File compiler = new File("compiler").exists() ? new File("compiler") : new File(".");
+        root = new File(compiler, "src/test/resources/functions");
+    }
+}

--- a/compiler/src/test/resources/com/github/mustachejava/functions/translatebundle_en.properties
+++ b/compiler/src/test/resources/com/github/mustachejava/functions/translatebundle_en.properties
@@ -1,1 +1,2 @@
 Label1=Translation bundles work!
+replaced.Label2=Post translate text works, too

--- a/compiler/src/test/resources/functions/bundles.html
+++ b/compiler/src/test/resources/functions/bundles.html
@@ -1,0 +1,2 @@
+{{#trans}}Label1{{/trans}}
+{{#trans}}{{replaceMe}}.Label2{{/trans}}

--- a/compiler/src/test/resources/functions/bundles_nulllabels.txt
+++ b/compiler/src/test/resources/functions/bundles_nulllabels.txt
@@ -1,0 +1,2 @@
+Translation bundles work!
+

--- a/compiler/src/test/resources/functions/bundles_post_labels.txt
+++ b/compiler/src/test/resources/functions/bundles_post_labels.txt
@@ -1,0 +1,2 @@
+Translation bundles work!
+Post translate text works, too

--- a/compiler/src/test/resources/functions/bundles_pre_labels.txt
+++ b/compiler/src/test/resources/functions/bundles_pre_labels.txt
@@ -1,0 +1,2 @@
+Translation bundles work!
+replaced.Label2


### PR DESCRIPTION
Adds `BundleFunctions` factory to create translation functions with different semantics regarding order of operation and unknown resource keys.

As I was updating `TranslateBundleFunction`'s constructor to be public, I realized it is limited by implementing `TemplateFunction` to _only_ operate prior to template evaluation. I also thought it was limiting that it in the case where an unknown resource key was provided it returned the key itself. The new class returns functions that can operate pre- or post-evaluation and that can return either `null` or the key itself in the case of an unknown key.
