### PR TITLE
Added basic Maven Plugin to validate mustache templates

### DIFF
--- a/mustache-maven-plugin/pom.xml
+++ b/mustache-maven-plugin/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.spullara.mustache.java</groupId>
+        <artifactId>mustache.java</artifactId>
+        <version>0.8.16-SNAPSHOT</version>
+    </parent>
+    <artifactId>mustache-maven-plugin</artifactId>
+    <version>0.8.16-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+    <name>mustache-maven-plugin Maven Mojo</name>
+    <url>http://maven.apache.org</url>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                    <!-- if you want to generate help goal -->
+                    <execution>
+                        <id>help-goal</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.2</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-api</artifactId>
+            <version>2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+            <version>0.8.16-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/mustache-maven-plugin/src/main/java/com/github/spullara/mustache/mojo/MustacheValidationMojo.java
+++ b/mustache-maven-plugin/src/main/java/com/github/spullara/mustache/mojo/MustacheValidationMojo.java
@@ -1,0 +1,65 @@
+package com.github.spullara.mustache.mojo;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.MustacheException;
+import com.github.mustachejava.MustacheFactory;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.plexus.compiler.util.scan.InclusionScanException;
+import org.codehaus.plexus.compiler.util.scan.SimpleSourceInclusionScanner;
+import org.codehaus.plexus.compiler.util.scan.SourceInclusionScanner;
+import org.codehaus.plexus.compiler.util.scan.StaleSourceScanner;
+import org.codehaus.plexus.compiler.util.scan.mapping.SuffixMapping;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@Mojo(name = "validate", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+public class MustacheValidationMojo extends AbstractMojo {
+
+  @Parameter(defaultValue = "src/main/resources")
+  private File sourceDirectory;
+
+  @Parameter(defaultValue = "target/classes")
+  private File outputDirectory;
+
+  @Parameter(defaultValue = "false")
+  private boolean includeStale;
+
+  public void execute() throws MojoExecutionException, MojoFailureException {
+
+    SourceInclusionScanner scanner = includeStale
+      ? new StaleSourceScanner(1024, Collections.singleton("**/*.mustache"), Collections.<String>emptySet())
+      : new SimpleSourceInclusionScanner(Collections.singleton("**/*.mustache"), Collections.<String>emptySet());
+
+    scanner.addSourceMapping(new SuffixMapping(".mustache", new HashSet(Arrays.asList(".mustache"))));
+
+    MustacheFactory mustacheFactory = new DefaultMustacheFactory();
+    try {
+      Set<File> files = scanner.getIncludedSources(sourceDirectory, outputDirectory);
+
+      for (File file : files) {
+        try {
+          mustacheFactory.compile(new FileReader(file), file.getAbsolutePath());
+        } catch (MustacheException e) {
+          throw new MojoFailureException(e.getMessage(), e);
+        }
+      }
+
+    } catch (InclusionScanException e) {
+      throw new MojoExecutionException(e.getMessage());
+    } catch (FileNotFoundException e) {
+      throw new MojoExecutionException(e.getMessage());
+    }
+
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -11,6 +12,7 @@
     <module>handlebar</module>
     <module>codegen</module>
     <module>indy</module>
+    <module>mustache-maven-plugin</module>
   </modules>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
This PR introduces a rudimentary plugin for the Apache Maven build tool to validate any mustache files found in the projects resources directory during the `process-resources` phase.

To enable, include the following in your projects pom.xml

```
<plugin>
  <groupId>com.github.spullara.mustache.java</groupId>
  <artifactId>mustache-maven-plugin</artifactId>
  <version>0.8.16-SNAPSHOT</version>
  <executions>
    <execution>
      <id>validate</id>
      <goals>
        <goal>validate</goal>
      </goals>
    </execution>
  </executions>
</plugin>
```
