### PR TITLE
fix partials resolution when name ends with extension

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
@@ -80,12 +80,19 @@ public class DefaultMustacheFactory implements MustacheFactory {
   }
 
   public String resolvePartialPath(String dir, String name, String extension) {
-    String path;
-    if (name.startsWith("/")) {
-      path = Files.simplifyPath(new File(name + extension).getPath());
-    } else {
-      path = Files.simplifyPath(new File(dir + name + extension).getPath());
+    String filePath = name;
+
+    // Do not prepend directory if it is already defined
+    if (!name.startsWith("/")) {
+      filePath = dir + filePath;
     }
+
+    // Do not append extension if it is already defined
+    if (!name.endsWith(extension)) {
+      filePath = filePath + extension;
+    }
+
+    String path = Files.simplifyPath(new File(filePath).getPath());
     return ensureForwardSlash(path);
   }
 

--- a/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
@@ -752,6 +752,14 @@ public class InterpreterTest extends TestCase {
     assertEquals(getContents(root, "relative/paths.txt"), sw.toString());
   }
 
+  public void testPathsWithExtension() throws IOException {
+    MustacheFactory mf = createMustacheFactory();
+    Mustache compile = mf.compile("relative/extension.html");
+    StringWriter sw = new StringWriter();
+    compile.execute(sw, null).close();
+    assertEquals(getContents(root, "relative/paths.txt"), sw.toString());
+  }
+
   public void testRelativePathsTemplateFunction() throws IOException {
     MustacheFactory mf = createMustacheFactory();
     Mustache compile = mf.compile("relative/functionpaths.html");

--- a/src/test/resources/relative/extension.html
+++ b/src/test/resources/relative/extension.html
@@ -1,0 +1,1 @@
+{{>/relative/include.html}}


### PR DESCRIPTION
When you define a template with partials, partials can now
ends with template extension, such as:

  <div>
    {{> myPartial.html}}
  </div>

If partial does not ends with extension, it will be
automatically appended during partial resolution.
