### PR TITLE
build scala-extensions for 2.11

### DIFF
--- a/scala-extensions/pom.xml
+++ b/scala-extensions/pom.xml
@@ -14,7 +14,7 @@
 
   <modules>
     <module>scala-extensions-2.10</module>
-<!--    <module>scala-extensions-2.11</module> -->
+    <module>scala-extensions-2.11</module>
   </modules>
   <packaging>pom</packaging>
 </project>

--- a/scala-extensions/scala-extensions-2.11/build.sbt
+++ b/scala-extensions/scala-extensions-2.11/build.sbt
@@ -1,0 +1,11 @@
+lazy val `scala-extensions-2-11` = project
+  .in(file("."))
+  .settings(
+    resolvers += Resolver.mavenLocal,
+    scalaVersion := "2.11.4",
+    libraryDependencies ++= Seq(
+      "com.github.spullara.mustache.java" % "compiler" % "0.8.17-SNAPSHOT",
+      "junit" % "junit" % "4.8.2" % "test",
+      "com.twitter" % "util-core" % "6.12.1"
+    )
+  )

--- a/scala-extensions/scala-extensions-2.11/pom.xml
+++ b/scala-extensions/scala-extensions-2.11/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>scala-extensions</artifactId>
+    <groupId>com.github.spullara.mustache.java</groupId>
+    <version>0.9.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>scala-extensions-2.11</artifactId>
+  <packaging>jar</packaging>
+
+  <name>scala-extensions-2.11</name>
+  <description>Scala extensions for mustache.java</description>
+  <url>http://github.com/spullara/mustache.java</url>
+
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Sam Pullara</name>
+      <email>sam@sampullara.com</email>
+      <url>http://www.javarants.com</url>
+    </developer>
+  </developers>
+
+  <repositories>
+    <repository>
+      <id>Twitter</id>
+      <url>http://maven.twttr.com/</url>
+    </repository>
+  </repositories>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.spullara.mustache.java</groupId>
+      <artifactId>compiler</artifactId>
+      <version>0.9.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.2</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Scala -->
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.11.4</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>util-core_2.11</artifactId>
+      <version>6.23.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.scala-tools</groupId>
+          <artifactId>maven-scala-plugin</artifactId>
+          <version>2.14.1</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.scala-tools</groupId>
+              <artifactId>maven-scala-plugin</artifactId>
+              <version>2.14.1</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.scala-tools</groupId>
+        <artifactId>maven-scala-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>scala-compile-first</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>add-source</goal>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>scala-test-compile</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/scala-extensions/scala-extensions-2.11/src/main/java/com/twitter/mustache/Javadoc.java
+++ b/scala-extensions/scala-extensions-2.11/src/main/java/com/twitter/mustache/Javadoc.java
@@ -1,0 +1,7 @@
+package com.twitter.mustache;
+
+/**
+ * Created by sam on 10/8/14.
+ */
+public class Javadoc {
+}

--- a/scala-extensions/scala-extensions-2.11/src/main/scala/com/twitter/mustache/ScalaObjectHandler.scala
+++ b/scala-extensions/scala-extensions-2.11/src/main/scala/com/twitter/mustache/ScalaObjectHandler.scala
@@ -1,0 +1,69 @@
+package com.twitter.mustache
+
+import collection.JavaConversions._
+import com.github.mustachejava.Iteration
+import com.github.mustachejava.reflect.ReflectionObjectHandler
+import java.io.Writer
+import java.lang.reflect.{Field, Method}
+import runtime.BoxedUnit
+import scala.reflect.ClassTag
+
+/**
+ * Plain old scala handler that doesn't depend on Twitter libraries.
+ */
+class ScalaObjectHandler extends ReflectionObjectHandler {
+
+  // Allow any method or field
+  override def checkMethod(member: Method) {}
+
+  override def checkField(member: Field) {}
+
+  override def coerce(value: AnyRef) = {
+    value match {
+      case m: collection.Map[_, _] => mapAsJavaMap(m)
+      case u: BoxedUnit => null
+      case Some(some: AnyRef) => coerce(some)
+      case None => null
+      case _ => value
+    }
+  }
+
+  override def iterate(iteration: Iteration, writer: Writer, value: AnyRef, scopes: Array[AnyRef]) = {
+    value match {
+      case TraversableAnyRef(t) => {
+        var newWriter = writer
+        t foreach {
+          next =>
+            newWriter = iteration.next(newWriter, coerce(next), scopes)
+        }
+        newWriter
+      }
+      case n: Number => if (n.intValue() == 0) writer else iteration.next(writer, coerce(value), scopes)
+      case _ => super.iterate(iteration, writer, value, scopes)
+    }
+  }
+
+  override def falsey(iteration: Iteration, writer: Writer, value: AnyRef, scopes: Array[AnyRef]) = {
+    value match {
+      case TraversableAnyRef(t) => {
+        if (t.isEmpty) {
+          iteration.next(writer, value, scopes)
+        } else {
+          writer
+        }
+      }
+      case n: Number => if (n.intValue() == 0) iteration.next(writer, coerce(value), scopes) else writer
+      case _ => super.falsey(iteration, writer, value, scopes)
+    }
+  }
+
+  val TraversableAnyRef = new Def[Traversable[AnyRef]]
+  class Def[C: ClassTag] {
+    def unapply[X: ClassTag](x: X): Option[C] = {
+      x match {
+        case c: C => Some(c)
+        case _ => None
+      }
+    }
+  }
+}

--- a/scala-extensions/scala-extensions-2.11/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
+++ b/scala-extensions/scala-extensions-2.11/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
@@ -1,0 +1,101 @@
+package com.twitter.mustache
+
+import com.github.mustachejava.DefaultMustacheFactory
+import com.twitter.util.{Future, FuturePool}
+import java.io.{StringWriter, StringReader}
+import java.util.concurrent.{Callable, Executors}
+import org.junit.{Assert, Test}
+
+class ObjectHandlerTest {
+
+  @Test
+  def testMap() {
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    val m = mf.compile(
+      new StringReader("{{#map}}{{test}}{{test2}}{{/map}}"),
+      "helloworld"
+    )
+    val sw = new StringWriter
+    val w = m.execute(sw, Map( "map" -> Map( "test" -> "fred" ) ) ).close()
+    Assert.assertEquals("fred", sw.toString())
+  }
+
+  @Test
+  def testScalaHandler() {
+    val pool = Executors.newCachedThreadPool()
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    mf.setExecutorService(pool)
+    val m = mf.compile(
+      new StringReader("{{#list}}{{optionalHello}}, {{futureWorld}}!" +
+              "{{#test}}?{{/test}}{{^test}}!{{/test}}{{#num}}?{{/num}}{{^num}}!{{/num}}" +
+              "{{#map}}{{value}}{{/map}}\n{{/list}}"),
+      "helloworld"
+    )
+    val sw = new StringWriter
+    val writer = m.execute(sw, new {
+      val list = Seq(new {
+        lazy val optionalHello = Some("Hello")
+        val futureWorld = new Callable[String] {
+          def call(): String = "world"
+        }
+        val test = true
+        val num = 0
+      }, new {
+        val optionalHello = Some("Goodbye")
+        val futureWorld = new Callable[String] {
+          def call(): String = "thanks for all the fish"
+        }
+        lazy val test = false
+        val map = Map(("value", "test"))
+        val num = 1
+      })
+    })
+    // You must use close if you use concurrent latched writers
+    writer.close()
+    Assert.assertEquals("Hello, world!?!\nGoodbye, thanks for all the fish!!?test\n", sw.toString)
+  }
+
+  @Test
+  def testScalaStream() {
+    val pool = Executors.newCachedThreadPool()
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    mf.setExecutorService(pool)
+    val m = mf.compile(new StringReader("{{#stream}}{{value}}{{/stream}}"), "helloworld")
+    val sw = new StringWriter
+    val writer = m.execute(sw, new {
+      val stream = Stream(
+        new { val value = "hello" },
+        new { val value = "world" })
+    })
+    writer.close()
+    Assert.assertEquals("helloworld", sw.toString)
+  }
+
+  @Test
+  def testUnit() {
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    val m = mf.compile(new StringReader("{{test}}"), "unit")
+    val sw = new StringWriter
+    m.execute(sw, new {
+      val test = if (false) "test"
+    }).close()
+    Assert.assertEquals("", sw.toString)
+  }
+
+  @Test
+  def testOptions() {
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    val m = mf.compile(new StringReader("{{foo}}{{bar}}"), "unit")
+    val sw = new StringWriter
+    m.execute(sw, new {
+      val foo = Some("Hello")
+      val bar = None
+    }).close()
+    Assert.assertEquals("Hello", sw.toString)
+  }
+}


### PR DESCRIPTION
This adds a target for `scala-extensions` to compile with version 2.11. Note that I opted to keep the current build structure of having `scala-extensions-{version}` and just copied the code to get it working, which didn't require any changes. I am usually very reluctant to copy code and the craftsman in me wants me to change the build so sbt will cross-compile the same code for different scala targets, but I assume the structure is there to be able to handle version differences so I went with this one for now. The only change required was to update `com.twitter.util-core` to the latest version, which has a 2.11 build available. 