### PR TITLE
Fix bug for templates with multiple recursive partials

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
@@ -226,14 +226,15 @@ public class DefaultMustacheFactory implements MustacheFactory {
    * @return the compiled partial
    */
   public Mustache compilePartial(String s) {
-    Map<String, Mustache> cache = partialCache.get();
+    final Map<String, Mustache> cache = partialCache.get();
+    final Mustache cached = cache.get(s);
+    if (cached != null) {
+      return cached;
+    }
     try {
-      Mustache mustache = cache.get(s);
-      if (mustache == null) {
-        mustache = mc.compile(s);
-        cache.put(s, mustache);
-        mustache.init();
-      }
+      final Mustache mustache = mc.compile(s);
+      cache.put(s, mustache);
+      mustache.init();
       return mustache;
     } finally {
       cache.remove(s);

--- a/compiler/src/test/java/com/github/mustachejava/MultipleRecursivePartialsTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/MultipleRecursivePartialsTest.java
@@ -1,0 +1,60 @@
+package com.github.mustachejava;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public final class MultipleRecursivePartialsTest {
+
+  private static final String TEMPLATE_FILE = "multiple_recursive_partials.html";
+
+  private static File root;
+  
+  @SuppressWarnings("unused")
+  private static class Model {
+    Type type;
+    List<Model> items;
+      
+    Model(Type type, List<Model> items) {
+      this.type = type;
+      this.items = items;
+    }
+      
+    Model(Type type) {
+      this.type = type;
+    }
+      
+    Type getType() { return type; }
+    List<Model> getItems() { return items; }
+  }
+  
+  @SuppressWarnings("unused")
+  private static enum Type {
+    FOO, BAR;
+    boolean isFoo () { return this == FOO; }
+    boolean isBar() { return this == BAR; }
+  }
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    File file = new File("compiler/src/test/resources");
+    root = new File(file, TEMPLATE_FILE).exists() ? file : new File("src/test/resources");
+  }
+
+  @Test
+  public void shouldHandleTemplateWithMultipleRecursivePartials() throws Exception {
+    MustacheFactory factory = new DefaultMustacheFactory(root);
+    Mustache template = factory.compile(TEMPLATE_FILE);
+    StringWriter sw = new StringWriter();
+    Model model = new Model(Type.FOO, Arrays.asList(new Model[] { new Model(Type.BAR), new Model(Type.FOO) }));
+    template.execute(sw, model);
+    assertEquals("I'm a foo!\nIn foo: I'm a bar!\n\nIn foo: I'm a foo!\n\n\n", sw.toString());
+  }
+
+}

--- a/compiler/src/test/resources/multiple_recursive_partials.html
+++ b/compiler/src/test/resources/multiple_recursive_partials.html
@@ -1,0 +1,8 @@
+{{#type.foo}}
+I'm a foo!
+{{#items}}In foo: {{> multiple_recursive_partials}}{{/items}}
+{{/type.foo}}
+{{#type.bar}}
+I'm a bar!
+{{#items}}In bar: {{> multiple_recursive_partials}}{{/items}}
+{{/type.bar}}


### PR DESCRIPTION
We recently ran into an issue where a template with multiple recursive partial invocations was failing to compile. After some debugging we realized there was a small bug when removing items from the `partialCache` in the `DefaultMustachFactory`.

I've documented this issue in #126