### PR TITLE
0.8.x: add TwitterObjectHandler to scala-extensions-2.10 and -2.11

### DIFF
--- a/scala-extensions/scala-extensions-2.10/build.sbt
+++ b/scala-extensions/scala-extensions-2.10/build.sbt
@@ -6,6 +6,6 @@ lazy val `scala-extensions-2-10` = project
     libraryDependencies ++= Seq(
       "com.github.spullara.mustache.java" % "compiler" % "0.8.17-SNAPSHOT",
       "junit" % "junit" % "4.8.2" % "test",
-      "com.twitter" % "util-core" % "6.12.1"
+      "com.twitter" % "util-core" % "6.23.0"
     )
   )

--- a/scala-extensions/scala-extensions-2.10/pom.xml
+++ b/scala-extensions/scala-extensions-2.10/pom.xml
@@ -62,8 +62,8 @@
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>util-core</artifactId>
-      <version>6.12.1</version>
+      <artifactId>util-core_2.10</artifactId>
+      <version>6.23.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/scala-extensions/scala-extensions-2.10/src/main/scala/com/twitter/mustache/TwitterObjectHandler.scala
+++ b/scala-extensions/scala-extensions-2.10/src/main/scala/com/twitter/mustache/TwitterObjectHandler.scala
@@ -1,0 +1,21 @@
+package com.twitter.mustache
+
+import com.twitter.util.Future
+import java.util.concurrent.Callable
+
+class TwitterObjectHandler extends ScalaObjectHandler {
+
+  override def coerce(value: Object) = {
+    value match {
+      case f: Future[_] => {
+        new Callable[Any]() {
+          def call() = {
+            val value = f.get().asInstanceOf[Object]
+            coerce(value)
+          }
+        }
+      }
+      case _ => super.coerce(value)
+    }
+  }
+}

--- a/scala-extensions/scala-extensions-2.10/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
+++ b/scala-extensions/scala-extensions-2.10/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
@@ -22,6 +22,43 @@ class ObjectHandlerTest {
   }
 
   @Test
+  def testTwitterHandler() {
+    val pool = Executors.newCachedThreadPool()
+    val futurePool = FuturePool(pool)
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new TwitterObjectHandler)
+    mf.setExecutorService(pool)
+    val m = mf.compile(
+      new StringReader("{{#list}}{{optionalHello}}, {{futureWorld}}!" +
+              "{{#test}}?{{/test}}{{^test}}!{{/test}}{{#num}}?{{/num}}{{^num}}!{{/num}}" +
+              "{{#map}}{{value}}{{/map}}\n{{/list}}"),
+      "helloworld"
+    )
+    val sw = new StringWriter
+    val writer = m.execute(sw, new {
+      val list = Seq(new {
+        lazy val optionalHello = Some("Hello")
+        val futureWorld = futurePool {
+          "world"
+        }
+        val test = true
+        val num = 0
+      }, new {
+        val optionalHello = Some("Goodbye")
+        val futureWorld = futurePool {
+          "thanks for all the fish"
+        }
+        lazy val test = Future { false }
+        val map = Map(("value", "test"))
+        val num = 1
+      })
+    })
+    // You must use close if you use concurrent latched writers
+    writer.close()
+    Assert.assertEquals("Hello, world!?!\nGoodbye, thanks for all the fish!!?test\n", sw.toString)
+  }
+
+  @Test
   def testScalaHandler() {
     val pool = Executors.newCachedThreadPool()
     val mf = new DefaultMustacheFactory()

--- a/scala-extensions/scala-extensions-2.11/src/main/scala/com/twitter/mustache/TwitterObjectHandler.scala
+++ b/scala-extensions/scala-extensions-2.11/src/main/scala/com/twitter/mustache/TwitterObjectHandler.scala
@@ -1,0 +1,21 @@
+package com.twitter.mustache
+
+import com.twitter.util.Future
+import java.util.concurrent.Callable
+
+class TwitterObjectHandler extends ScalaObjectHandler {
+
+  override def coerce(value: Object) = {
+    value match {
+      case f: Future[_] => {
+        new Callable[Any]() {
+          def call() = {
+            val value = f.get().asInstanceOf[Object]
+            coerce(value)
+          }
+        }
+      }
+      case _ => super.coerce(value)
+    }
+  }
+}

--- a/scala-extensions/scala-extensions-2.11/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
+++ b/scala-extensions/scala-extensions-2.11/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
@@ -22,6 +22,43 @@ class ObjectHandlerTest {
   }
 
   @Test
+  def testTwitterHandler() {
+    val pool = Executors.newCachedThreadPool()
+    val futurePool = FuturePool(pool)
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new TwitterObjectHandler)
+    mf.setExecutorService(pool)
+    val m = mf.compile(
+      new StringReader("{{#list}}{{optionalHello}}, {{futureWorld}}!" +
+              "{{#test}}?{{/test}}{{^test}}!{{/test}}{{#num}}?{{/num}}{{^num}}!{{/num}}" +
+              "{{#map}}{{value}}{{/map}}\n{{/list}}"),
+      "helloworld"
+    )
+    val sw = new StringWriter
+    val writer = m.execute(sw, new {
+      val list = Seq(new {
+        lazy val optionalHello = Some("Hello")
+        val futureWorld = futurePool {
+          "world"
+        }
+        val test = true
+        val num = 0
+      }, new {
+        val optionalHello = Some("Goodbye")
+        val futureWorld = futurePool {
+          "thanks for all the fish"
+        }
+        lazy val test = Future { false }
+        val map = Map(("value", "test"))
+        val num = 1
+      })
+    })
+    // You must use close if you use concurrent latched writers
+    writer.close()
+    Assert.assertEquals("Hello, world!?!\nGoodbye, thanks for all the fish!!?test\n", sw.toString)
+  }
+
+  @Test
   def testScalaHandler() {
     val pool = Executors.newCachedThreadPool()
     val mf = new DefaultMustacheFactory()


### PR DESCRIPTION
like https://github.com/spullara/mustache.java/pull/150 but for the 0.8.x branch and for -2.10 and -2.11