### PR TITLE
compiler module repackaged as an OSGi bundle

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>compiler</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <name>compiler</name>
   <description>Implementation of mustache.js for Java</description>
@@ -87,6 +87,16 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <!--<Export-Package>*</Export-Package>
+            <Import-Package>*</Import-Package>-->
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.3.7</version>
+          <version>2.5.0</version>
           <extensions>true</extensions>
           <executions>
             <execution>


### PR DESCRIPTION
I had to upgrade the maven-bundle-plugin since the previous version was unable to process most of my Java 1.8.0_60 class files.