### PR TITLE
Add support for renaming tags in translations

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/functions/TranslateBundleFunction.java
+++ b/compiler/src/main/java/com/github/mustachejava/functions/TranslateBundleFunction.java
@@ -22,6 +22,7 @@ import java.util.ResourceBundle;
  * Usage in template:
  *   ... {{#trans}}TranslatedLabel1{{/trans}} ...
  *
+ *   ... {{#trans}}TranslatedLabel2 param1=newparam1 param2=newparma2{{/trans}}
  * @author gw0 [http://gw.tnode.com/] &lt;gw.2012@tnode.com&gt;
  */
 public class TranslateBundleFunction implements TemplateFunction {
@@ -41,10 +42,18 @@ public class TranslateBundleFunction implements TemplateFunction {
 	/** Return translation from the localized ResourceBundle. */
 	@Override
 	public String apply(String input) {
-		if(res.containsKey(input)) {
-			return res.getString(input);  // return translation
-		} else {
+ 		String[] inputWithParams = input.split(" ");
+ 		String key = inputWithParams[0];
+		if(!res.containsKey(key)) {
 			return input;  // return untranslated label
 		}
+		String translatedValue = res.getString(key);
+		for (int i = 1; i < inputWithParams.length; i++) {
+			String[] splitParam = inputWithParams[i].split("=");
+			String oldTag = splitParam[0];
+			String newTag = splitParam[1];
+			translatedValue = translatedValue.replace("{{" + oldTag + "}}", "{{" + newTag + "}}");
+		}
+		return translatedValue;
 	}
 }


### PR DESCRIPTION
When using a mustache tag in a translation the user may want to
rename this tag for the specific template.

For example if you have a salutation template.

    salutation=Hello {{user}},

You may want to change this for a specific template to be:

    Hello {{account}},

You could simply type:

    {{#trans}}salutation user=account{{/trans}}