### PR TITLE
BUG-172: fix issue if there is a comment in an ExtendCode block

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/codes/ExtendCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/ExtendCode.java
@@ -1,6 +1,10 @@
 package com.github.mustachejava.codes;
 
-import com.github.mustachejava.*;
+import com.github.mustachejava.Code;
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheException;
+import com.github.mustachejava.TemplateContext;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,8 +65,8 @@ public class ExtendCode extends PartialCode {
         ExtendNameCode erc = (ExtendNameCode) code;
         replaceMap.put(erc.getName(), erc);
         erc.init();
-      } else if (code instanceof WriteCode) {
-        // ignore text
+      } else if ((code instanceof WriteCode) || (code instanceof CommentCode)) {
+        // ignore text and comments
       } else {
         // fail on everything else
         throw new IllegalArgumentException(

--- a/compiler/src/test/java/com/github/mustachejava/functions/CommentTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/functions/CommentTest.java
@@ -23,7 +23,6 @@ public class CommentTest {
   @Test
   public void testCommentBlock() throws MustacheException, IOException, ExecutionException, InterruptedException {
     File root = getRoot("comment.html");
-    System.out.println("****** using root: " + root);
     MustacheFactory c = new DefaultMustacheFactory(root);
     Mustache m = c.compile("comment.html");
     StringWriter sw = new StringWriter();
@@ -35,21 +34,19 @@ public class CommentTest {
 
   @Test
   public void testCommentInline() throws MustacheException, IOException, ExecutionException, InterruptedException {
-    File root = getRoot("commentInline.html");
-    System.out.println("****** using root: " + root);
+    File root = getRoot("commentinline.html");
     MustacheFactory c = new DefaultMustacheFactory(root);
-    Mustache m = c.compile("commentInline.html");
+    Mustache m = c.compile("commentinline.html");
     StringWriter sw = new StringWriter();
     Map scope = new HashMap();
     scope.put("title", "A Comedy of Errors");
     m.execute(sw, scope);
-    assertEquals(getContents(root, "commentInline.txt"), sw.toString());
+    assertEquals(getContents(root, "commentinline.txt"), sw.toString());
   }
 
   @Test
   public void testInlineCommentWithinExtendCodeBlock() throws MustacheException, IOException, ExecutionException, InterruptedException {
     File root = getRoot("commentWithinExtendCodeBlock.html");
-    System.out.println("****** using root: " + root);
     MustacheFactory c = new DefaultMustacheFactory(root);
     Mustache m = c.compile("commentWithinExtendCodeBlock.html");
     StringWriter sw = new StringWriter();

--- a/compiler/src/test/java/com/github/mustachejava/functions/CommentTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/functions/CommentTest.java
@@ -4,10 +4,14 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheFactory;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -28,6 +32,26 @@ public class CommentTest {
     scope.put("ignored", "ignored");
     m.execute(sw, scope);
     assertEquals(getContents(root, "comment.txt"), sw.toString());
+  }
+
+  @Test
+  public void testCommentInline() throws MustacheException, IOException, ExecutionException, InterruptedException {
+    MustacheFactory c = new DefaultMustacheFactory(root);
+    Mustache m = c.compile("commentInline.html");
+    StringWriter sw = new StringWriter();
+    Map scope = new HashMap();
+    scope.put("title", "A Comedy of Errors");
+    m.execute(sw, scope);
+    assertEquals(getContents(root, "commentInline.txt"), sw.toString());
+  }
+
+  @Test
+  public void testInlineCommentWithinExtendCodeBlock() throws MustacheException, IOException, ExecutionException, InterruptedException {
+    MustacheFactory c = new DefaultMustacheFactory(root);
+    Mustache m = c.compile("commentWithinExtendCodeBlock.html");
+    StringWriter sw = new StringWriter();
+    m.execute(sw, Collections.emptyList());
+    assertEquals(getContents(root, "commentWithinExtendCodeBlock.txt"), sw.toString());
   }
 
   @BeforeClass

--- a/compiler/src/test/java/com/github/mustachejava/functions/CommentTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/functions/CommentTest.java
@@ -5,7 +5,6 @@ import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheFactory;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -21,10 +20,9 @@ import static org.junit.Assert.assertEquals;
 
 public class CommentTest {
 
-  private static File root;
-
   @Test
   public void testCommentBlock() throws MustacheException, IOException, ExecutionException, InterruptedException {
+    File root = getRoot("comment.html");
     MustacheFactory c = new DefaultMustacheFactory(root);
     Mustache m = c.compile("comment.html");
     StringWriter sw = new StringWriter();
@@ -36,6 +34,7 @@ public class CommentTest {
 
   @Test
   public void testCommentInline() throws MustacheException, IOException, ExecutionException, InterruptedException {
+    File root = getRoot("commentInline.html");
     MustacheFactory c = new DefaultMustacheFactory(root);
     Mustache m = c.compile("commentInline.html");
     StringWriter sw = new StringWriter();
@@ -47,6 +46,7 @@ public class CommentTest {
 
   @Test
   public void testInlineCommentWithinExtendCodeBlock() throws MustacheException, IOException, ExecutionException, InterruptedException {
+    File root = getRoot("commentWithinExtendCodeBlock.html");
     MustacheFactory c = new DefaultMustacheFactory(root);
     Mustache m = c.compile("commentWithinExtendCodeBlock.html");
     StringWriter sw = new StringWriter();
@@ -54,9 +54,8 @@ public class CommentTest {
     assertEquals(getContents(root, "commentWithinExtendCodeBlock.txt"), sw.toString());
   }
 
-  @BeforeClass
-  public static void setUp() throws Exception {
+  private File getRoot(String fileName) {
     File file = new File("compiler/src/test/resources/functions");
-    root = new File(file, "comment.html").exists() ? file : new File("src/test/resources/functions");
+    return new File(file, fileName).exists() ? file : new File("src/test/resources/functions");
   }
 }

--- a/compiler/src/test/java/com/github/mustachejava/functions/CommentTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/functions/CommentTest.java
@@ -23,6 +23,7 @@ public class CommentTest {
   @Test
   public void testCommentBlock() throws MustacheException, IOException, ExecutionException, InterruptedException {
     File root = getRoot("comment.html");
+    System.out.println("****** using root: " + root);
     MustacheFactory c = new DefaultMustacheFactory(root);
     Mustache m = c.compile("comment.html");
     StringWriter sw = new StringWriter();
@@ -35,6 +36,7 @@ public class CommentTest {
   @Test
   public void testCommentInline() throws MustacheException, IOException, ExecutionException, InterruptedException {
     File root = getRoot("commentInline.html");
+    System.out.println("****** using root: " + root);
     MustacheFactory c = new DefaultMustacheFactory(root);
     Mustache m = c.compile("commentInline.html");
     StringWriter sw = new StringWriter();
@@ -47,6 +49,7 @@ public class CommentTest {
   @Test
   public void testInlineCommentWithinExtendCodeBlock() throws MustacheException, IOException, ExecutionException, InterruptedException {
     File root = getRoot("commentWithinExtendCodeBlock.html");
+    System.out.println("****** using root: " + root);
     MustacheFactory c = new DefaultMustacheFactory(root);
     Mustache m = c.compile("commentWithinExtendCodeBlock.html");
     StringWriter sw = new StringWriter();

--- a/compiler/src/test/resources/functions/commentWithinExtendCodeBlock.html
+++ b/compiler/src/test/resources/functions/commentWithinExtendCodeBlock.html
@@ -1,0 +1,6 @@
+{{<commentWithinExtendCodeBlock_sub}}
+
+  {{! just something interesting... or not... }}
+  {{$title}}Just for the fun of it{{/title}}
+
+{{/commentWithinExtendCodeBlock_sub}}

--- a/compiler/src/test/resources/functions/commentWithinExtendCodeBlock.txt
+++ b/compiler/src/test/resources/functions/commentWithinExtendCodeBlock.txt
@@ -1,0 +1,1 @@
+<h1>Just for the fun of it</h1>

--- a/compiler/src/test/resources/functions/commentWithinExtendCodeBlock_sub.html
+++ b/compiler/src/test/resources/functions/commentWithinExtendCodeBlock_sub.html
@@ -1,0 +1,1 @@
+<h1>{{$title}}{{/title}}{{! just something interesting... or not... }}</h1>

--- a/compiler/src/test/resources/functions/commentinline.html
+++ b/compiler/src/test/resources/functions/commentinline.html
@@ -1,0 +1,1 @@
+<h1>{{title}}{{! just something interesting... or not... }}</h1>

--- a/compiler/src/test/resources/functions/commentinline.txt
+++ b/compiler/src/test/resources/functions/commentinline.txt
@@ -1,0 +1,1 @@
+<h1>A Comedy of Errors</h1>


### PR DESCRIPTION
If there is a comment in an ExtendCode block of a mustache template, the ExtendCode.init method fails with a IllegalArgumentException. For example, the templates below will fail:

**commentWithinExtendCodeBlock.html**
```
{{<commentWithinExtendCodeBlock_sub}}

  {{! just something interesting... or not... }}
  {{$title}}Just for the fun of it{{/title}}

{{/commentWithinExtendCodeBlock_sub}}
```

**commentWithinExtendCodeBlock_sub.html**
`<h1>{{$title}}{{/title}}{{! just something interesting... or not... }}</h1>`

I don't believe that a comment in this location should be considered illegal. 

This fix updates the if statement in ExtendCode.init to include CommentCode is the types of codes ignored:

`} else if ((code instanceof WriteCode) || (code instanceof CommentCode)) {`