### PR TITLE
fix a problem that cannot load resource named relative path with dot on Windows

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/resolver/ClasspathResolver.java
+++ b/compiler/src/main/java/com/github/mustachejava/resolver/ClasspathResolver.java
@@ -6,6 +6,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -33,11 +34,12 @@ public class ClasspathResolver implements MustacheResolver {
         ClassLoader ccl = Thread.currentThread().getContextClassLoader();
 
         String fullResourceName = concatResourceRootAndResourceName(resourceName);
+        String normalizeResourceName = URI.create(fullResourceName).normalize().getPath();
 
-        InputStream is = ccl.getResourceAsStream(fullResourceName);
+        InputStream is = ccl.getResourceAsStream(normalizeResourceName);
         if (is == null) {
             ClassLoader classLoader = ClasspathResolver.class.getClassLoader();
-            is = classLoader.getResourceAsStream(fullResourceName);
+            is = classLoader.getResourceAsStream(normalizeResourceName);
         }
 
         if (is != null) {

--- a/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
@@ -65,4 +65,17 @@ public class ClasspathResolverTest {
         underTest.getReader(null);
     }
 
+    @Test
+    public void getReaderWithRootAndResourceHasDoubleDotRelativePath() throws Exception {
+        ClasspathResolver underTest = new ClasspathResolver("templates");
+        Reader reader = underTest.getReader("absolute/../absolute_partials_template.html");
+        assertThat(reader, is(notNullValue()));
+    }
+
+    @Test
+    public void getReaderWithRootAndResourceHasDotRelativePath() throws Exception {
+        ClasspathResolver underTest = new ClasspathResolver("templates");
+        Reader reader = underTest.getReader("absolute/./nested_partials_sub.html");
+        assertThat(reader, is(notNullValue()));
+    }
 }


### PR DESCRIPTION
## issue
Tomcat on windows system cannot load partial templates in jar.
> 22:09:27.967 [ajp-bio-8009-exec-1] ERROR c.n.e.c.web.advice.ExceptionAdvice - Template mustache/document/card/component/../sub/align.mustache not found
com.github.mustachejava.MustacheNotFoundException: Template mustache/document/card/component/../sub/align.mustache not found
    at com.github.mustachejava.DefaultMustacheFactory.getReader(DefaultMustacheFactory.java:112)

## root cause
In Windows System, ClassLoader.getResourceAsStream could not find resource named with `../` or `./`
i don't know why.
i guess File.separator in Windows is not `/` but `\`

## solution
`resourceName` to normalized uri path by removing redundancies
* mustache/document/card/component/../sub/align.mustache -> mustache/document/card/sub/align.mustache