### PR TITLE
Standardise on a single version of jackson (2.7.4)

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -37,15 +37,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.3</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>

--- a/benchmarks/src/main/java/mustachejava/benchmarks/TweetBench.java
+++ b/benchmarks/src/main/java/mustachejava/benchmarks/TweetBench.java
@@ -1,11 +1,11 @@
 package mustachejava.benchmarks;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheResolver;
 import com.github.mustachejavabenchmarks.NullWriter;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.MappingJsonFactory;
 import org.openjdk.jmh.annotations.*;
 
 import java.io.*;
@@ -80,7 +80,7 @@ public class TweetBench {
     try {
       MappingJsonFactory jf = new MappingJsonFactory();
       InputStream json = TweetBench.class.getClassLoader().getResourceAsStream("tweet.json");
-      jsonScope = new ArrayList<>(singletonList(new JsonMap(jf.createJsonParser(json).readValueAsTree())));
+      jsonScope = new ArrayList<>(singletonList(new JsonMap(jf.createParser(json).readValueAsTree())));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -117,7 +117,7 @@ public class TweetBench {
 
     InputStream json = TweetBench.class.getClassLoader().getResourceAsStream("tweet.json");
     MappingJsonFactory jf = new MappingJsonFactory();
-    JsonNode jsonNode = jf.createJsonParser(json).readValueAsTree();
+    JsonNode jsonNode = jf.createParser(json).readValueAsTree();
     sw = new StringWriter();
     m.execute(sw, new JsonMap(jsonNode)).close();
     System.out.println(sw);
@@ -149,7 +149,7 @@ public class TweetBench {
     private Object convert(final JsonNode value) {
       if (value == null || value.isNull()) return null;
       if (value.isBoolean()) {
-        return value.getBooleanValue();
+        return value.booleanValue();
       } else if (value.isValueNode()) {
         return value.asText();
       } else if (value.isArray()) {

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -56,13 +56,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.7.4</version>
+      <version>${jackson.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.7.4</version>
+      <version>${jackson.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/handlebar/pom.xml
+++ b/handlebar/pom.xml
@@ -30,9 +30,14 @@
       <version>0.9.5-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.4</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
     </dependency>
 
     <!-- Jetty -->

--- a/handlebar/src/main/java/com/sampullara/mustache/Handlebar.java
+++ b/handlebar/src/main/java/com/sampullara/mustache/Handlebar.java
@@ -1,17 +1,17 @@
 package com.sampullara.mustache;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.github.mustachejava.TemplateFunction;
 import com.sampullara.cli.Args;
 import com.sampullara.cli.Argument;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.MappingJsonFactory;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
@@ -89,7 +89,7 @@ public class Handlebar {
     } else if (node.isObject()) {
       return new HashMap() {
         {
-          for (Iterator<Map.Entry<String, JsonNode>> i = node.getFields(); i.hasNext();) {
+          for (Iterator<Map.Entry<String, JsonNode>> i = node.fields(); i.hasNext();) {
             Map.Entry<String, JsonNode> next = i.next();
             Object o = toObject(next.getValue());
             put(next.getKey(), o);
@@ -97,7 +97,7 @@ public class Handlebar {
         }
       };
     } else if (node.isBoolean()) {
-      return node.getBooleanValue();
+      return node.booleanValue();
     } else if (node.isNull()) {
       return null;
     } else {
@@ -223,7 +223,7 @@ public class Handlebar {
         if (file.exists()) {
           BufferedReader br =
               new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
-          JsonParser parser = JSON_FACTORY.createJsonParser(br);
+          JsonParser parser = JSON_FACTORY.createParser(br);
           JsonNode json = parser.readValueAsTree();
           br.close();
           scs.add(0, toObject(json));

--- a/javascript/pom.xml
+++ b/javascript/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.7.4</version>
+      <version>${jackson.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
   <name>mustache.java</name>
   <url>http://github.com/spullara/mustache.java</url>
 
+  <properties>
+    <jackson.version>2.7.4</jackson.version>
+  </properties>
+
   <developers>
     <developer>
       <id>spullara</id>


### PR DESCRIPTION
Several versions of jackson were needed to build mustache, 1.9.3,
1.9.4 and 2.7.4. This change makes all modules use the same version
of jackson for consistency and to reduce number of dependencies.

Signed-off-by: Mat Booth <mat.booth@redhat.com>