### PR TITLE
Add test cases for scala handler dot notation with classes

### DIFF
--- a/scala-extensions/scala-extensions-2.10/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
+++ b/scala-extensions/scala-extensions-2.10/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
@@ -22,6 +22,38 @@ class ObjectHandlerTest {
   }
 
   @Test
+  def testClass() {
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    val m = mf.compile(
+      new StringReader("{{#map}}{{test}}{{test2}}{{/map}}"),
+      "helloworld"
+    )
+    case class TestClass(
+      test: String
+    )
+    val sw = new StringWriter
+    val w = m.execute(sw, Map( "map" -> TestClass("fred") ) ).close()
+    Assert.assertEquals("fred", sw.toString())
+  }
+
+  @Test
+  def testClassDot() {
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    val m = mf.compile(
+      new StringReader("{{map.test}}"),
+      "helloworld"
+    )
+    case class TestClass(
+      test: String
+    )
+    val sw = new StringWriter
+    val w = m.execute(sw, Map( "map" -> TestClass("fred") ) ).close()
+    Assert.assertEquals("fred", sw.toString())
+  }
+
+  @Test
   def testTwitterHandler() {
     val pool = Executors.newCachedThreadPool()
     val futurePool = FuturePool(pool)

--- a/scala-extensions/scala-extensions-2.11/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
+++ b/scala-extensions/scala-extensions-2.11/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
@@ -22,6 +22,38 @@ class ObjectHandlerTest {
   }
 
   @Test
+  def testClass() {
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    val m = mf.compile(
+      new StringReader("{{#map}}{{test}}{{test2}}{{/map}}"),
+      "helloworld"
+    )
+    case class TestClass(
+      test: String
+    )
+    val sw = new StringWriter
+    val w = m.execute(sw, Map( "map" -> TestClass("fred") ) ).close()
+    Assert.assertEquals("fred", sw.toString())
+  }
+
+  @Test
+  def testClassDot() {
+    val mf = new DefaultMustacheFactory()
+    mf.setObjectHandler(new ScalaObjectHandler)
+    val m = mf.compile(
+      new StringReader("{{map.test}}"),
+      "helloworld"
+    )
+    case class TestClass(
+      test: String
+    )
+    val sw = new StringWriter
+    val w = m.execute(sw, Map( "map" -> TestClass("fred") ) ).close()
+    Assert.assertEquals("fred", sw.toString())
+  }
+
+  @Test
   def testScalaHandler() {
     val pool = Executors.newCachedThreadPool()
     val mf = new DefaultMustacheFactory()


### PR DESCRIPTION
Passing in a class as a value for the context works when you use standard notation:
{{#classValue}}
   {{classMember}}
{{/classValue}}

However, it throws a notFound/guard error when referenced directly:
{{classValue.classMember}}

This added two tests to illustrate the differences, with the dot notation one failing