### PR TITLE
refs #168 Enabling different file extension

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
@@ -92,8 +92,11 @@ public class DefaultMustacheFactory implements MustacheFactory {
       filePath = dir + filePath;
     }
 
-    // Do not append extension if it is already defined
-    if (!name.endsWith(extension)) {
+    int sepIndex = name.lastIndexOf("/");
+    name = sepIndex == -1 ? name : name.substring(sepIndex);
+    
+    // Do not append extension if it has the same extension or original one
+    if (!(name.endsWith(extension) || name.contains("."))) {
       filePath = filePath + extension;
     }
 

--- a/compiler/src/test/java/com/github/mustachejava/ExtensionTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/ExtensionTest.java
@@ -157,6 +157,15 @@ public class ExtensionTest {
     m.execute(sw, new Object() {});
     assertEquals(getContents(root, "nested_inheritance.txt"), sw.toString());
   }
+  
+  @Test
+  public void testDiffExt() throws IOException {
+    MustacheFactory c = new DefaultMustacheFactory(root);
+    Mustache m = c.compile("diffext.mustache.parent");
+    StringWriter sw = new StringWriter();
+    m.execute(sw, new Object() {});
+    assertEquals(getContents(root, "diffext.txt"), sw.toString());
+  }
 
   @BeforeClass
   public static void setUp() throws Exception {

--- a/compiler/src/test/resources/diffext.mustache.child
+++ b/compiler/src/test/resources/diffext.mustache.child
@@ -1,0 +1,2 @@
+child
+{{>diffext.mustache.grandchild}}

--- a/compiler/src/test/resources/diffext.mustache.grandchild
+++ b/compiler/src/test/resources/diffext.mustache.grandchild
@@ -1,0 +1,1 @@
+grandchild

--- a/compiler/src/test/resources/diffext.mustache.parent
+++ b/compiler/src/test/resources/diffext.mustache.parent
@@ -1,0 +1,2 @@
+parent
+{{>diffext.mustache.child}}

--- a/compiler/src/test/resources/diffext.txt
+++ b/compiler/src/test/resources/diffext.txt
@@ -1,0 +1,3 @@
+parent
+child
+grandchild


### PR DESCRIPTION
Enable to specify partial file which has different extention from its parent.
(The specification that the extention can be omitted in the case it's same as the parent's one is still remained.)