### PR TITLE
Fix all whitespace -- alternative approach

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/Code.java
+++ b/compiler/src/main/java/com/github/mustachejava/Code.java
@@ -1,5 +1,6 @@
 package com.github.mustachejava;
 
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.Node;
 
 import java.io.Writer;
@@ -11,9 +12,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Code objects that are executed in order to evaluate the template
  */
 public interface Code {
-  Writer execute(Writer writer, List<Object> scopes);
+  IndentWriter execute(IndentWriter writer, List<Object> scopes);
 
-  void identity(Writer writer);
+  void identity(IndentWriter writer);
 
   void append(String text);
 

--- a/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java
@@ -35,7 +35,7 @@ public class DefaultMustacheFactory implements MustacheFactory {
   /**
    * This parser should work with any MustacheFactory
    */
-  protected final MustacheParser mc = new MustacheParser(this);
+  protected final MustacheParser mc = createParser();
 
   /**
    * New templates that are generated at runtime are cached here. The template key
@@ -257,6 +257,10 @@ public class DefaultMustacheFactory implements MustacheFactory {
     } finally {
       cache.remove(s);
     }
+  }
+
+  protected MustacheParser createParser() {
+    return new MustacheParser(this);
   }
 
   protected Function<String, Mustache> getMustacheCacheFunction() {

--- a/compiler/src/main/java/com/github/mustachejava/DefaultMustacheVisitor.java
+++ b/compiler/src/main/java/com/github/mustachejava/DefaultMustacheVisitor.java
@@ -66,7 +66,7 @@ public class DefaultMustacheVisitor implements MustacheVisitor {
   @Override
   public void partial(TemplateContext tc, final String variable, String indent) {
     TemplateContext partialTC = new TemplateContext("{{", "}}", tc.file(), tc.line(), tc.startOfLine());
-    list.add(new PartialCode(partialTC, df, variable, indent));
+    list.add(new PartialCode(partialTC, df, variable));
   }
 
   @Override

--- a/compiler/src/main/java/com/github/mustachejava/DefaultMustacheVisitor.java
+++ b/compiler/src/main/java/com/github/mustachejava/DefaultMustacheVisitor.java
@@ -64,9 +64,9 @@ public class DefaultMustacheVisitor implements MustacheVisitor {
   }
 
   @Override
-  public void partial(TemplateContext tc, final String variable) {
+  public void partial(TemplateContext tc, final String variable, String indent) {
     TemplateContext partialTC = new TemplateContext("{{", "}}", tc.file(), tc.line(), tc.startOfLine());
-    list.add(new PartialCode(partialTC, df, variable));
+    list.add(new PartialCode(partialTC, df, variable, indent));
   }
 
   @Override

--- a/compiler/src/main/java/com/github/mustachejava/DeferringMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/DeferringMustacheFactory.java
@@ -73,7 +73,7 @@ public class DeferringMustacheFactory extends DefaultMustacheFactory {
       public void partial(TemplateContext tc, final String variable, final String indent) {
         TemplateContext partialTC = new TemplateContext("{{", "}}", tc.file(), tc.line(), tc.startOfLine());
         final Long divid = id.incrementAndGet();
-        list.add(new PartialCode(partialTC, df, variable, indent) {
+        list.add(new PartialCode(partialTC, df, variable) {
           Wrapper deferredWrapper;
 
           @Override

--- a/compiler/src/main/java/com/github/mustachejava/DeferringMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/DeferringMustacheFactory.java
@@ -70,10 +70,10 @@ public class DeferringMustacheFactory extends DefaultMustacheFactory {
     final AtomicLong id = new AtomicLong(0);
     return new DefaultMustacheVisitor(this) {
       @Override
-      public void partial(TemplateContext tc, final String variable) {
+      public void partial(TemplateContext tc, final String variable, final String indent) {
         TemplateContext partialTC = new TemplateContext("{{", "}}", tc.file(), tc.line(), tc.startOfLine());
         final Long divid = id.incrementAndGet();
-        list.add(new PartialCode(partialTC, df, variable) {
+        list.add(new PartialCode(partialTC, df, variable, indent) {
           Wrapper deferredWrapper;
 
           @Override

--- a/compiler/src/main/java/com/github/mustachejava/DeferringMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/DeferringMustacheFactory.java
@@ -2,6 +2,7 @@ package com.github.mustachejava;
 
 import com.github.mustachejava.codes.PartialCode;
 import com.github.mustachejava.util.GuardException;
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.InternalArrayList;
 import com.github.mustachejava.util.Wrapper;
 
@@ -77,7 +78,7 @@ public class DeferringMustacheFactory extends DefaultMustacheFactory {
           Wrapper deferredWrapper;
 
           @Override
-          public Writer execute(Writer writer, final List<Object> scopes) {
+          public IndentWriter execute(IndentWriter writer, final List<Object> scopes) {
 
             final Object object = get(scopes);
             final DeferredCallable deferredCallable = getDeferred(scopes);

--- a/compiler/src/main/java/com/github/mustachejava/Iteration.java
+++ b/compiler/src/main/java/com/github/mustachejava/Iteration.java
@@ -1,5 +1,7 @@
 package com.github.mustachejava;
 
+import com.github.mustachejava.util.IndentWriter;
+
 import java.io.Writer;
 import java.util.List;
 
@@ -8,5 +10,5 @@ import java.util.List;
  * method in an ObjectHandler to change the types recognized by mustache.java as iterable.
  */
 public interface Iteration {
-  Writer next(Writer writer, Object next, List<Object> scopes);
+  IndentWriter next(IndentWriter writer, Object next, List<Object> scopes);
 }

--- a/compiler/src/main/java/com/github/mustachejava/Mustache.java
+++ b/compiler/src/main/java/com/github/mustachejava/Mustache.java
@@ -1,5 +1,7 @@
 package com.github.mustachejava;
 
+import com.github.mustachejava.util.BaseIndentWriter;
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.InternalArrayList;
 import com.github.mustachejava.util.Node;
 
@@ -53,7 +55,11 @@ public interface Mustache extends Code {
    * @param scopes an ordered list of scopes for variable resolution
    * @return the new writer
    */
-  Writer execute(Writer writer, List<Object> scopes);
+  default Writer execute(Writer writer, List<Object> scopes) {
+    return execute(new BaseIndentWriter(writer), scopes);
+  }
+
+  IndentWriter execute(IndentWriter writer, List<Object> scopes);
 
   /**
    * Get the underlying code objects.
@@ -67,7 +73,11 @@ public interface Mustache extends Code {
    *
    * @param writer write the output of the executed template here
    */
-  void identity(Writer writer);
+  void identity(IndentWriter writer);
+
+  default void identity(Writer writer) {
+    this.identity(new BaseIndentWriter(writer));
+  }
 
   /**
    * Initialize the mustache before executing. This is must be called at least once
@@ -89,7 +99,7 @@ public interface Mustache extends Code {
    * @param scopes the array of scopes to execute
    * @return the replacement writer
    */
-  Writer run(Writer writer, List<Object> scopes);
+  IndentWriter run(IndentWriter writer, List<Object> scopes);
 
   /**
    * Invert this mustache given output text.

--- a/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
+++ b/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
@@ -193,7 +193,7 @@ public class MustacheParser {
                   mv.partial(new TemplateContext(sm, em, file, currentLine.get(), startOfLine), variable, indent);
 
                   // a new line following a partial is dropped
-                  chompNewline(startOfLine, br);
+                  trimNewline(startOfLine, br);
                   break;
                 }
                 case '{': {
@@ -240,7 +240,7 @@ public class MustacheParser {
                   break;
                 case '=':
                   // Change delimiters
-                  if (chompNewline(startOfLine & onlywhitespace, br)) {
+                  if (trimNewline(startOfLine & onlywhitespace, br)) {
                     // indented standalone tags drop the preceding whitespace
                     out = new StringBuilder();
                   } else {
@@ -320,11 +320,11 @@ public class MustacheParser {
    * For backwards compatibility we only do this if the parser is explicitly configured so.
    * @param firstStmt If the statement that was just read was at the start of line with only whitespace preceding it
    * @param br The reader
-   * @return true if a following new line was chomped or the buffer was finished
+   * @return true if trimming was allowed and a following new line was removed or the buffer was finished;
    * @throws IOException
    */
-  private boolean chompNewline(boolean firstStmt, Reader br) throws IOException {
-    boolean chomped = false;
+  private boolean trimNewline(boolean firstStmt, Reader br) throws IOException {
+    boolean trimmed = false;
 
     if (specConformWhitespace && firstStmt) {
       br.mark(2);
@@ -334,12 +334,12 @@ public class MustacheParser {
       }
 
       if (ca == '\n' || ca == -1) {
-        chomped = true;
+        trimmed = true;
       } else {
         br.reset();
       }
     }
 
-    return chomped;
+    return trimmed;
   }
 }

--- a/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
+++ b/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
@@ -16,10 +16,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class MustacheParser {
   public static final String DEFAULT_SM = "{{";
   public static final String DEFAULT_EM = "}}";
+  private final boolean specConformWhitespace;
   private MustacheFactory mf;
 
-  protected MustacheParser(MustacheFactory mf) {
+  protected MustacheParser(MustacheFactory mf, boolean specConformWhitespace) {
     this.mf = mf;
+    this.specConformWhitespace = specConformWhitespace;
+  }
+
+  protected MustacheParser(MustacheFactory mf) {
+    this(mf, false);
   }
 
   public Mustache compile(String file) {
@@ -187,7 +193,7 @@ public class MustacheParser {
                   mv.partial(new TemplateContext(sm, em, file, currentLine.get(), startOfLine), variable, indent);
 
                   // a new line following a partial is dropped
-                  if (startOfLine) {
+                  if (specConformWhitespace && startOfLine) {
                     br.mark(2);
                     int ca = br.read();
                     if (ca == '\r') {

--- a/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
+++ b/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
@@ -193,14 +193,7 @@ public class MustacheParser {
                   mv.partial(new TemplateContext(sm, em, file, currentLine.get(), startOfLine), variable, indent);
 
                   // a new line following a partial is dropped
-                  if (specConformWhitespace && startOfLine) {
-                    br.mark(2);
-                    int ca = br.read();
-                    if (ca == '\r') {
-                      ca = br.read();
-                    }
-                    if (ca != '\n') br.reset();
-                  }
+                  chompNewline(startOfLine, br);
                   break;
                 }
                 case '{': {
@@ -256,6 +249,9 @@ public class MustacheParser {
                   }
                   sm = split[0];
                   em = split[1];
+
+                  chompNewline(startOfLine, br);
+
                   break;
                 default: {
                   if (c == -1) {
@@ -314,4 +310,23 @@ public class MustacheParser {
     return new StringBuilder();
   }
 
+  /**
+   * Some statements such as partials are treated as "standalone".
+   * This means that if they are the only content on this line (except whitespace) then the following newline is
+   * chopped.
+   * For backwards compatibility we only do this if the parser is explicitly configured so.
+   * @param startOfLine If the statement that was just read was at the start of line
+   * @param br The reader
+   * @throws IOException
+   */
+  private void chompNewline(boolean startOfLine, Reader br) throws IOException {
+    if (specConformWhitespace && startOfLine) {
+      br.mark(2);
+      int ca = br.read();
+      if (ca == '\r') {
+        ca = br.read();
+      }
+      if (ca != '\n') br.reset();
+    }
+  }
 }

--- a/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
+++ b/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
@@ -181,9 +181,20 @@ public class MustacheParser {
                   return mv.mustache(new TemplateContext(sm, em, file, 0, startOfLine));
                 }
                 case '>': {
+                  String indent = (onlywhitespace && startOfLine) ? out.toString() : "";
                   out = write(mv, out, file, currentLine.intValue(), startOfLine);
                   startOfLine = startOfLine & onlywhitespace;
-                  mv.partial(new TemplateContext(sm, em, file, currentLine.get(), startOfLine), variable);
+                  mv.partial(new TemplateContext(sm, em, file, currentLine.get(), startOfLine), variable, indent);
+
+                  // a new line following a partial is dropped
+                  if (startOfLine) {
+                    br.mark(2);
+                    int ca = br.read();
+                    if (ca == '\r') {
+                      ca = br.read();
+                    }
+                    if (ca != '\n') br.reset();
+                  }
                   break;
                 }
                 case '{': {

--- a/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
+++ b/compiler/src/main/java/com/github/mustachejava/MustacheParser.java
@@ -80,7 +80,7 @@ public class MustacheParser {
           // Increment the line
           if (c == '\n') {
             currentLine.incrementAndGet();
-            if (!iterable || (iterable && !onlywhitespace)) {
+            if (specConformWhitespace || !iterable || (iterable && !onlywhitespace)) {
               if (sawCR) out.append("\r");
               out.append("\n");
             }
@@ -146,13 +146,16 @@ public class MustacheParser {
                 case '$': {
                   boolean oldStartOfLine = startOfLine;
                   startOfLine = startOfLine & onlywhitespace;
-                  int line = currentLine.get();
-                  final Mustache mustache = compile(br, variable, currentLine, file, sm, em, startOfLine);
-                  int lines = currentLine.get() - line;
-                  if (!onlywhitespace || lines == 0) {
+
+                  if (!trimNewline(startOfLine, br)) {
                     write(mv, out, file, currentLine.intValue(), oldStartOfLine);
                   }
                   out = new StringBuilder();
+
+                  int line = currentLine.get();
+                  final Mustache mustache = compile(br, variable, currentLine, file, sm, em, startOfLine);
+                  int lines = currentLine.get() - line;
+
                   switch (ch) {
                     case '#':
                       mv.iterable(new TemplateContext(sm, em, file, line, startOfLine), variable, mustache);
@@ -175,7 +178,7 @@ public class MustacheParser {
                 }
                 case '/': {
                   // Tag end
-                  if (!startOfLine || !onlywhitespace) {
+                  if (!trimNewline(onlywhitespace & startOfLine, br)) {
                     write(mv, out, file, currentLine.intValue(), startOfLine);
                   }
                   if (!variable.equals(tag)) {

--- a/compiler/src/main/java/com/github/mustachejava/MustacheVisitor.java
+++ b/compiler/src/main/java/com/github/mustachejava/MustacheVisitor.java
@@ -12,7 +12,7 @@ public interface MustacheVisitor {
 
   void notIterable(TemplateContext templateContext, String variable, Mustache mustache);
 
-  void partial(TemplateContext templateContext, String variable);
+  void partial(TemplateContext templateContext, String variable, String indent);
 
   void value(TemplateContext templateContext, String variable, boolean encoded);
 

--- a/compiler/src/main/java/com/github/mustachejava/ObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/ObjectHandler.java
@@ -1,5 +1,6 @@
 package com.github.mustachejava;
 
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.InternalArrayList;
 import com.github.mustachejava.util.Wrapper;
 
@@ -37,7 +38,7 @@ public interface ObjectHandler {
    * @param scopes the scopes present
    * @return the current writer
    */
-  Writer iterate(Iteration iteration, Writer writer, Object object, List<Object> scopes);
+  IndentWriter iterate(Iteration iteration, IndentWriter writer, Object object, List<Object> scopes);
 
   /**
    * Call Iteration.next() either 0 (true) or 1 (fale) times.
@@ -48,7 +49,7 @@ public interface ObjectHandler {
    * @param scopes the scopes present
    * @return the current writer
    */
-  Writer falsey(Iteration iteration, Writer writer, Object object, List<Object> scopes);
+  IndentWriter falsey(Iteration iteration, IndentWriter writer, Object object, List<Object> scopes);
 
   /**
    * Each call site has its own binding to allow for fine grained caching without

--- a/compiler/src/main/java/com/github/mustachejava/SpecMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/SpecMustacheFactory.java
@@ -1,0 +1,12 @@
+package com.github.mustachejava;
+
+/**
+ * This factory is similar to DefaultMustacheFactory but handles whitespace according to the mustache specification.
+ * Therefore the rendering is less performant than with the DefaultMustacheFactory.
+ */
+public class SpecMustacheFactory extends DefaultMustacheFactory {
+    @Override
+    public MustacheVisitor createMustacheVisitor() {
+        return new SpecMustacheVisitor(this);
+    }
+}

--- a/compiler/src/main/java/com/github/mustachejava/SpecMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/SpecMustacheFactory.java
@@ -9,34 +9,39 @@ import java.io.File;
  * Therefore the rendering is less performant than with the DefaultMustacheFactory.
  */
 public class SpecMustacheFactory extends DefaultMustacheFactory {
-    @Override
-    public MustacheVisitor createMustacheVisitor() {
-        return new SpecMustacheVisitor(this);
-    }
+  @Override
+  public MustacheVisitor createMustacheVisitor() {
+      return new SpecMustacheVisitor(this);
+  }
 
-    public SpecMustacheFactory() {
-        super();
-    }
+  public SpecMustacheFactory() {
+      super();
+  }
 
-    public SpecMustacheFactory(MustacheResolver mustacheResolver) {
-        super(mustacheResolver);
-    }
+  public SpecMustacheFactory(MustacheResolver mustacheResolver) {
+      super(mustacheResolver);
+  }
 
-    /**
-     * Use the classpath to resolve mustache templates.
-     *
-     * @param classpathResourceRoot the location in the resources where templates are stored
-     */
-    public SpecMustacheFactory(String classpathResourceRoot) {
-        super(classpathResourceRoot);
-    }
+  /**
+   * Use the classpath to resolve mustache templates.
+   *
+   * @param classpathResourceRoot the location in the resources where templates are stored
+   */
+  public SpecMustacheFactory(String classpathResourceRoot) {
+      super(classpathResourceRoot);
+  }
 
-    /**
-     * Use the file system to resolve mustache templates.
-     *
-     * @param fileRoot the root of the file system where templates are stored
-     */
-    public SpecMustacheFactory(File fileRoot) {
+  /**
+   * Use the file system to resolve mustache templates.
+   *
+   * @param fileRoot the root of the file system where templates are stored
+   */
+  public SpecMustacheFactory(File fileRoot) {
         super(fileRoot);
     }
+
+  @Override
+  protected MustacheParser createParser() {
+    return new MustacheParser(this, true);
+  }
 }

--- a/compiler/src/main/java/com/github/mustachejava/SpecMustacheFactory.java
+++ b/compiler/src/main/java/com/github/mustachejava/SpecMustacheFactory.java
@@ -1,5 +1,9 @@
 package com.github.mustachejava;
 
+import com.github.mustachejava.resolver.DefaultResolver;
+
+import java.io.File;
+
 /**
  * This factory is similar to DefaultMustacheFactory but handles whitespace according to the mustache specification.
  * Therefore the rendering is less performant than with the DefaultMustacheFactory.
@@ -8,5 +12,31 @@ public class SpecMustacheFactory extends DefaultMustacheFactory {
     @Override
     public MustacheVisitor createMustacheVisitor() {
         return new SpecMustacheVisitor(this);
+    }
+
+    public SpecMustacheFactory() {
+        super();
+    }
+
+    public SpecMustacheFactory(MustacheResolver mustacheResolver) {
+        super(mustacheResolver);
+    }
+
+    /**
+     * Use the classpath to resolve mustache templates.
+     *
+     * @param classpathResourceRoot the location in the resources where templates are stored
+     */
+    public SpecMustacheFactory(String classpathResourceRoot) {
+        super(classpathResourceRoot);
+    }
+
+    /**
+     * Use the file system to resolve mustache templates.
+     *
+     * @param fileRoot the root of the file system where templates are stored
+     */
+    public SpecMustacheFactory(File fileRoot) {
+        super(fileRoot);
     }
 }

--- a/compiler/src/main/java/com/github/mustachejava/SpecMustacheVisitor.java
+++ b/compiler/src/main/java/com/github/mustachejava/SpecMustacheVisitor.java
@@ -1,0 +1,62 @@
+package com.github.mustachejava;
+
+import com.github.mustachejava.codes.PartialCode;
+import com.github.mustachejava.codes.ValueCode;
+import com.github.mustachejava.util.IndentWriter;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+public class SpecMustacheVisitor extends DefaultMustacheVisitor {
+  public SpecMustacheVisitor(DefaultMustacheFactory df) {
+    super(df);
+  }
+
+  @Override
+  public void partial(TemplateContext tc, final String variable, String indent) {
+    TemplateContext partialTC = new TemplateContext("{{", "}}", tc.file(), tc.line(), tc.startOfLine());
+    list.add(new SpecPartialCode(partialTC, df, variable, indent));
+  }
+
+  @Override
+  public void value(TemplateContext tc, final String variable, boolean encoded) {
+    list.add(new SpecValueCode(tc, df, variable, encoded));
+  }
+
+  static class SpecPartialCode extends PartialCode {
+    private final String indent;
+
+    public SpecPartialCode(TemplateContext tc, DefaultMustacheFactory cf, String variable, String indent) {
+      super(tc, cf, variable);
+      this.indent = indent;
+    }
+
+    @Override
+    protected Writer executePartial(Writer writer, final List<Object> scopes) {
+      partial.execute(new IndentWriter(writer, indent), scopes);
+      return writer;
+    }
+  }
+
+  static class SpecValueCode extends ValueCode {
+
+    public SpecValueCode(TemplateContext tc, DefaultMustacheFactory df, String variable, boolean encoded) {
+      super(tc, df, variable, encoded);
+    }
+
+    @Override
+    protected void execute(Writer writer, final String value) throws IOException {
+      if (writer instanceof IndentWriter) {
+        IndentWriter iw = (IndentWriter) writer;
+        iw.flushIndent();
+        writer = iw.inner;
+        while (writer instanceof IndentWriter) {
+          writer = ((IndentWriter) writer).inner;
+        }
+      }
+
+      super.execute(writer, value);
+    }
+  }
+}

--- a/compiler/src/main/java/com/github/mustachejava/SpecMustacheVisitor.java
+++ b/compiler/src/main/java/com/github/mustachejava/SpecMustacheVisitor.java
@@ -3,6 +3,7 @@ package com.github.mustachejava;
 import com.github.mustachejava.codes.PartialCode;
 import com.github.mustachejava.codes.ValueCode;
 import com.github.mustachejava.util.IndentWriter;
+import com.github.mustachejava.util.InnerIndentWriter;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -19,44 +20,18 @@ public class SpecMustacheVisitor extends DefaultMustacheVisitor {
     list.add(new SpecPartialCode(partialTC, df, variable, indent));
   }
 
-  @Override
-  public void value(TemplateContext tc, final String variable, boolean encoded) {
-    list.add(new SpecValueCode(tc, df, variable, encoded));
-  }
-
   static class SpecPartialCode extends PartialCode {
-    private final String indent;
+    private final char[] indent;
 
     public SpecPartialCode(TemplateContext tc, DefaultMustacheFactory cf, String variable, String indent) {
       super(tc, cf, variable);
-      this.indent = indent;
+      this.indent = indent.toCharArray();
     }
 
     @Override
-    protected Writer executePartial(Writer writer, final List<Object> scopes) {
-      partial.execute(new IndentWriter(writer, indent), scopes);
+    protected IndentWriter executePartial(IndentWriter writer, final List<Object> scopes) {
+      partial.execute(new InnerIndentWriter(writer, indent), scopes);
       return writer;
-    }
-  }
-
-  static class SpecValueCode extends ValueCode {
-
-    public SpecValueCode(TemplateContext tc, DefaultMustacheFactory df, String variable, boolean encoded) {
-      super(tc, df, variable, encoded);
-    }
-
-    @Override
-    protected void execute(Writer writer, final String value) throws IOException {
-      if (writer instanceof IndentWriter) {
-        IndentWriter iw = (IndentWriter) writer;
-        iw.flushIndent();
-        writer = iw.inner;
-        while (writer instanceof IndentWriter) {
-          writer = ((IndentWriter) writer).inner;
-        }
-      }
-
-      super.execute(writer, value);
     }
   }
 }

--- a/compiler/src/main/java/com/github/mustachejava/TypeCheckingHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/TypeCheckingHandler.java
@@ -1,6 +1,7 @@
 package com.github.mustachejava;
 
 import com.github.mustachejava.reflect.BaseObjectHandler;
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.Wrapper;
 
 import java.io.Writer;
@@ -59,13 +60,13 @@ public class TypeCheckingHandler extends BaseObjectHandler {
   }
 
   @Override
-  public Writer falsey(Iteration iteration, Writer writer, Object object, List<Object> scopes) {
+  public IndentWriter falsey(Iteration iteration, IndentWriter writer, Object object, List<Object> scopes) {
     // Iterate once in either case
     return iterate(iteration, writer, object, scopes);
   }
 
   @Override
-  public Writer iterate(Iteration iteration, Writer writer, Object object, List<Object> scopes) {
+  public IndentWriter iterate(Iteration iteration, IndentWriter writer, Object object, List<Object> scopes) {
     return iteration.next(writer, object, scopes);
   }
 

--- a/compiler/src/main/java/com/github/mustachejava/codes/DefaultCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/DefaultCode.java
@@ -7,6 +7,7 @@ import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.ObjectHandler;
 import com.github.mustachejava.TemplateContext;
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.Node;
 
 import java.io.IOException;
@@ -158,12 +159,12 @@ public class DefaultCode implements Code, Cloneable {
    * @param scopes The scopes to evaluate the embedded names against.
    */
   @Override
-  public Writer execute(Writer writer, List<Object> scopes) {
+  public IndentWriter execute(IndentWriter writer, List<Object> scopes) {
     return appendText(run(writer, scopes));
   }
 
   @Override
-  public void identity(Writer writer) {
+  public void identity(IndentWriter writer) {
     try {
       if (name != null) {
         tag(writer, type);
@@ -178,7 +179,7 @@ public class DefaultCode implements Code, Cloneable {
     }
   }
 
-  protected void runIdentity(Writer writer) {
+  protected void runIdentity(IndentWriter writer) {
     int length = getCodes().length;
     for (int i = 0; i < length; i++) {
       getCodes()[i].identity(writer);
@@ -192,16 +193,21 @@ public class DefaultCode implements Code, Cloneable {
     writer.write(tc.endChars());
   }
 
-  private char[] appendedChars;
+  private char[][] appendedLines;
   
-  protected Writer appendText(Writer writer) {
+  protected IndentWriter appendText(IndentWriter writer) {
     if (appended != null) {
       try {
         // Avoid allocations at runtime
-        if (appendedChars == null) {
-          appendedChars = appended.toCharArray();
+        if (appendedLines == null) {
+            String[] ls = appended.split("\n", -1);
+            appendedLines = new char[ls.length][];
+
+            for (int i = 0; i < ls.length; ++i) {
+                appendedLines[i] = ls[i].toCharArray();
+            }
         }
-        writer.write(appendedChars);
+        writer.writeLines(appendedLines);
       } catch (IOException e) {
         throw new MustacheException("Failed to write", e, tc);
       }
@@ -209,7 +215,7 @@ public class DefaultCode implements Code, Cloneable {
     return writer;
   }
 
-  protected Writer run(Writer writer, List<Object> scopes) {
+  protected IndentWriter run(IndentWriter writer, List<Object> scopes) {
     return mustache == null ? writer : mustache.run(writer, scopes);
   }
 

--- a/compiler/src/main/java/com/github/mustachejava/codes/DefaultMustache.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/DefaultMustache.java
@@ -4,6 +4,8 @@ import com.github.mustachejava.Code;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.TemplateContext;
+import com.github.mustachejava.util.BaseIndentWriter;
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.InternalArrayList;
 import com.github.mustachejava.util.Node;
 
@@ -28,7 +30,7 @@ public class DefaultMustache extends DefaultCode implements Mustache {
     return codes;
   }
 
-  public Writer run(Writer writer, List<Object> scopes) {
+  public IndentWriter run(IndentWriter writer, List<Object> scopes) {
     if (codes != null) {
       for (Code code : codes) {
         writer = code.execute(writer, scopes);
@@ -48,7 +50,7 @@ public class DefaultMustache extends DefaultCode implements Mustache {
   }
 
   @Override
-  public Writer execute(Writer writer, List<Object> scopes) {
+  public IndentWriter execute(IndentWriter writer, List<Object> scopes) {
     if (!(scopes instanceof InternalArrayList)) {
       // This is the only place where we explicitly allocate post initialization for a compiled mustache
       // in order to track the scopes as you descend the template. It ends up being ~200 bytes.
@@ -58,7 +60,7 @@ public class DefaultMustache extends DefaultCode implements Mustache {
   }
 
   @Override
-  public void identity(Writer writer) {
+  public void identity(IndentWriter writer) {
     // No self output at the top level
     runIdentity(writer);
   }

--- a/compiler/src/main/java/com/github/mustachejava/codes/DepthLimitedWriter.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/DepthLimitedWriter.java
@@ -1,12 +1,16 @@
 package com.github.mustachejava.codes;
 
+import com.github.mustachejava.util.AbstractIndentWriter;
+import com.github.mustachejava.util.IndentWriter;
+
 import java.io.FilterWriter;
+import java.io.IOException;
 import java.io.Writer;
 import java.util.concurrent.atomic.AtomicInteger;
 
-class DepthLimitedWriter extends FilterWriter {
+class DepthLimitedWriter extends AbstractIndentWriter {
   private AtomicInteger depth = new AtomicInteger(0);
-  public DepthLimitedWriter(Writer writer) {
+  public DepthLimitedWriter(IndentWriter writer) {
     super(writer);
   }
 

--- a/compiler/src/main/java/com/github/mustachejava/codes/ExtendCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/ExtendCode.java
@@ -23,7 +23,7 @@ public class ExtendCode extends PartialCode {
   private final DefaultMustacheFactory mf;
 
   public ExtendCode(TemplateContext tc, DefaultMustacheFactory mf, Mustache codes, String name) throws MustacheException {
-    super(tc, mf, codes, "<", name);
+    super(tc, mf, codes, "<", name, "");
     this.mf = mf;
   }
 

--- a/compiler/src/main/java/com/github/mustachejava/codes/ExtendCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/ExtendCode.java
@@ -23,7 +23,7 @@ public class ExtendCode extends PartialCode {
   private final DefaultMustacheFactory mf;
 
   public ExtendCode(TemplateContext tc, DefaultMustacheFactory mf, Mustache codes, String name) throws MustacheException {
-    super(tc, mf, codes, "<", name, "");
+    super(tc, mf, codes, "<", name);
     this.mf = mf;
   }
 

--- a/compiler/src/main/java/com/github/mustachejava/codes/NotIterableCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/NotIterableCode.java
@@ -3,6 +3,7 @@ package com.github.mustachejava.codes;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.TemplateContext;
+import com.github.mustachejava.util.IndentWriter;
 
 import java.io.Writer;
 import java.util.List;
@@ -18,14 +19,14 @@ public class NotIterableCode extends IterableCode {
   }
 
   @Override
-  public Writer execute(Writer writer, final List<Object> scopes) {
+  public IndentWriter execute(IndentWriter writer, final List<Object> scopes) {
     Object resolved = get(scopes);
     writer = handle(writer, resolved, scopes);
     appendText(writer);
     return writer;
   }
 
-  protected Writer handle(Writer writer, Object resolved, List<Object> scopes) {
+  protected IndentWriter handle(IndentWriter writer, Object resolved, List<Object> scopes) {
     if (resolved instanceof Callable) {
       writer = handleCallable(writer, (Callable) resolved, scopes);
     } else {
@@ -35,12 +36,12 @@ public class NotIterableCode extends IterableCode {
   }
 
   @Override
-  protected Writer execute(Writer writer, Object resolve, List<Object> scopes) {
+  protected IndentWriter execute(IndentWriter writer, Object resolve, List<Object> scopes) {
     return oh.falsey(this, writer, resolve, scopes);
   }
 
   @Override
-  public Writer next(Writer writer, Object object, List<Object> scopes) {
+  public IndentWriter next(IndentWriter writer, Object object, List<Object> scopes) {
     return run(writer, scopes);
   }
 }

--- a/compiler/src/main/java/com/github/mustachejava/codes/PartialCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/PartialCode.java
@@ -1,7 +1,6 @@
 package com.github.mustachejava.codes;
 
 import com.github.mustachejava.*;
-import com.github.mustachejava.util.IndentWriter;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -14,12 +13,8 @@ public class PartialCode extends DefaultCode {
   protected int recrusionLimit;
   protected boolean isRecursive;
 
-  private final String indent;
-
-  protected PartialCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String type, String variable, String indent) {
+  protected PartialCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String type, String variable) {
     super(tc, df, mustache, variable, type);
-
-    this.indent = indent;
 
     // Use the  name of the parent to get the name of the partial
     String file = tc.file();
@@ -30,8 +25,8 @@ public class PartialCode extends DefaultCode {
     recrusionLimit = df.getRecursionLimit();
   }
 
-  public PartialCode(TemplateContext tc, DefaultMustacheFactory cf, String variable, String indent) {
-    this(tc, cf, null, ">", variable, indent);
+  public PartialCode(TemplateContext tc, DefaultMustacheFactory cf, String variable) {
+    this(tc, cf, null, ">", variable);
   }
 
   @Override
@@ -73,12 +68,16 @@ public class PartialCode extends DefaultCode {
       }
       writer = depthLimitedWriter;
     }
-    partial.execute(new IndentWriter(writer, indent), scopes);
+    Writer execute = executePartial(writer, scopes);
     if (isRecursive) {
       assert depthLimitedWriter != null;
       depthLimitedWriter.decr();
     }
-    return appendText(writer);
+    return appendText(execute);
+  }
+
+  protected Writer executePartial(Writer writer, final List<Object> scopes) {
+    return partial.execute(writer, scopes);
   }
 
   @Override

--- a/compiler/src/main/java/com/github/mustachejava/codes/PartialCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/PartialCode.java
@@ -1,6 +1,7 @@
 package com.github.mustachejava.codes;
 
 import com.github.mustachejava.*;
+import com.github.mustachejava.util.IndentWriter;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -30,7 +31,7 @@ public class PartialCode extends DefaultCode {
   }
 
   @Override
-  public void identity(Writer writer) {
+  public void identity(IndentWriter writer) {
     try {
       if (name != null) {
         super.tag(writer, type);
@@ -52,7 +53,7 @@ public class PartialCode extends DefaultCode {
   }
 
   @Override
-  public Writer execute(Writer writer, final List<Object> scopes) {
+  public IndentWriter execute(IndentWriter writer, final List<Object> scopes) {
     DepthLimitedWriter depthLimitedWriter = null;
     // If the mustache wasn't found to recurse at compilation time we
     // don't need to track the recursion depth and therefore don't need
@@ -68,7 +69,7 @@ public class PartialCode extends DefaultCode {
       }
       writer = depthLimitedWriter;
     }
-    Writer execute = executePartial(writer, scopes);
+    IndentWriter execute = executePartial(writer, scopes);
     if (isRecursive) {
       assert depthLimitedWriter != null;
       depthLimitedWriter.decr();
@@ -76,7 +77,7 @@ public class PartialCode extends DefaultCode {
     return appendText(execute);
   }
 
-  protected Writer executePartial(Writer writer, final List<Object> scopes) {
+  protected IndentWriter executePartial(IndentWriter writer, final List<Object> scopes) {
     return partial.execute(writer, scopes);
   }
 

--- a/compiler/src/main/java/com/github/mustachejava/codes/PartialCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/PartialCode.java
@@ -1,6 +1,7 @@
 package com.github.mustachejava.codes;
 
 import com.github.mustachejava.*;
+import com.github.mustachejava.util.IndentWriter;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -13,8 +14,13 @@ public class PartialCode extends DefaultCode {
   protected int recrusionLimit;
   protected boolean isRecursive;
 
-  protected PartialCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String type, String variable) {
+  private final String indent;
+
+  protected PartialCode(TemplateContext tc, DefaultMustacheFactory df, Mustache mustache, String type, String variable, String indent) {
     super(tc, df, mustache, variable, type);
+
+    this.indent = indent;
+
     // Use the  name of the parent to get the name of the partial
     String file = tc.file();
     int dotindex = file.lastIndexOf(".");
@@ -24,8 +30,8 @@ public class PartialCode extends DefaultCode {
     recrusionLimit = df.getRecursionLimit();
   }
 
-  public PartialCode(TemplateContext tc, DefaultMustacheFactory cf, String variable) {
-    this(tc, cf, null, ">", variable);
+  public PartialCode(TemplateContext tc, DefaultMustacheFactory cf, String variable, String indent) {
+    this(tc, cf, null, ">", variable, indent);
   }
 
   @Override
@@ -67,12 +73,12 @@ public class PartialCode extends DefaultCode {
       }
       writer = depthLimitedWriter;
     }
-    Writer execute = partial.execute(writer, scopes);
+    partial.execute(new IndentWriter(writer, indent), scopes);
     if (isRecursive) {
       assert depthLimitedWriter != null;
       depthLimitedWriter.decr();
     }
-    return appendText(execute);
+    return appendText(writer);
   }
 
   @Override

--- a/compiler/src/main/java/com/github/mustachejava/codes/ValueCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/ValueCode.java
@@ -4,6 +4,7 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.FragmentKey;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.TemplateContext;
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.LatchedWriter;
 import com.github.mustachejava.util.Node;
 
@@ -75,6 +76,18 @@ public class ValueCode extends DefaultCode {
     }
   }
 
+  private Writer getInnerWriter(Writer w) throws IOException {
+    if (w instanceof IndentWriter) {
+      IndentWriter iw = (IndentWriter) w;
+      iw.flushIndent();
+      w = iw.inner;
+      while (w instanceof IndentWriter) {
+        w = ((IndentWriter) w).inner;
+      }
+    }
+    return w;
+  }
+
   protected Writer handleCallable(Writer writer, final Callable callable, final List<Object> scopes) throws Exception {
     if (les == null) {
       Object call = callable.call();
@@ -125,9 +138,9 @@ public class ValueCode extends DefaultCode {
     // Treat null values as the empty string
     if (value != null) {
       if (encoded) {
-        df.encode(value, writer);
+        df.encode(value, getInnerWriter(writer));
       } else {
-        writer.write(value);
+        getInnerWriter(writer).write(value);
       }
     }
   }

--- a/compiler/src/main/java/com/github/mustachejava/codes/ValueCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/ValueCode.java
@@ -4,6 +4,7 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.FragmentKey;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.TemplateContext;
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.LatchedWriter;
 import com.github.mustachejava.util.Node;
 
@@ -30,7 +31,7 @@ public class ValueCode extends DefaultCode {
   private final ExecutorService les;
 
   @Override
-  public void identity(Writer writer) {
+  public void identity(IndentWriter writer) {
     try {
       if (name != null) {
         writer.write(tc.startChars());
@@ -57,7 +58,7 @@ public class ValueCode extends DefaultCode {
   }
 
   @Override
-  public Writer execute(Writer writer, final List<Object> scopes) {
+  public IndentWriter execute(IndentWriter writer, final List<Object> scopes) {
     try {
       final Object object = get(scopes);
       if (object != null) {
@@ -75,7 +76,7 @@ public class ValueCode extends DefaultCode {
     }
   }
 
-  protected Writer handleCallable(Writer writer, final Callable callable, final List<Object> scopes) throws Exception {
+  protected IndentWriter handleCallable(IndentWriter writer, final Callable callable, final List<Object> scopes) throws Exception {
     if (les == null) {
       Object call = callable.call();
       execute(writer, call == null ? null : oh.stringify(call));

--- a/compiler/src/main/java/com/github/mustachejava/codes/ValueCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/ValueCode.java
@@ -4,7 +4,6 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.FragmentKey;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.TemplateContext;
-import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.LatchedWriter;
 import com.github.mustachejava.util.Node;
 
@@ -76,18 +75,6 @@ public class ValueCode extends DefaultCode {
     }
   }
 
-  private Writer getInnerWriter(Writer w) throws IOException {
-    if (w instanceof IndentWriter) {
-      IndentWriter iw = (IndentWriter) w;
-      iw.flushIndent();
-      w = iw.inner;
-      while (w instanceof IndentWriter) {
-        w = ((IndentWriter) w).inner;
-      }
-    }
-    return w;
-  }
-
   protected Writer handleCallable(Writer writer, final Callable callable, final List<Object> scopes) throws Exception {
     if (les == null) {
       Object call = callable.call();
@@ -138,9 +125,9 @@ public class ValueCode extends DefaultCode {
     // Treat null values as the empty string
     if (value != null) {
       if (encoded) {
-        df.encode(value, getInnerWriter(writer));
+        df.encode(value, writer);
       } else {
-        getInnerWriter(writer).write(value);
+        writer.write(value);
       }
     }
   }

--- a/compiler/src/main/java/com/github/mustachejava/codes/WriteCode.java
+++ b/compiler/src/main/java/com/github/mustachejava/codes/WriteCode.java
@@ -2,6 +2,7 @@ package com.github.mustachejava.codes;
 
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.TemplateContext;
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejava.util.Node;
 
 import java.io.Writer;
@@ -19,7 +20,7 @@ public class WriteCode extends DefaultCode {
   }
 
   @Override
-  public void identity(Writer writer) {
+  public void identity(IndentWriter writer) {
     execute(writer, null);
   }
 

--- a/compiler/src/main/java/com/github/mustachejava/reflect/BaseObjectHandler.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/BaseObjectHandler.java
@@ -5,6 +5,7 @@ import com.github.mustachejava.Code;
 import com.github.mustachejava.Iteration;
 import com.github.mustachejava.ObjectHandler;
 import com.github.mustachejava.TemplateContext;
+import com.github.mustachejava.util.IndentWriter;
 
 import java.io.Writer;
 import java.lang.reflect.AccessibleObject;
@@ -31,7 +32,7 @@ public abstract class BaseObjectHandler implements ObjectHandler {
   }
 
   @Override
-  public Writer falsey(Iteration iteration, Writer writer, Object object, List<Object> scopes) {
+  public IndentWriter falsey(Iteration iteration, IndentWriter writer, Object object, List<Object> scopes) {
     if (object != null) {
       if (object instanceof Boolean) {
         if ((Boolean) object) {
@@ -66,7 +67,7 @@ public abstract class BaseObjectHandler implements ObjectHandler {
   public abstract Binding createBinding(String name, TemplateContext tc, Code code);
 
   @SuppressWarnings("ForLoopReplaceableByForEach") // it allocates objects for foreach
-  public Writer iterate(Iteration iteration, Writer writer, Object object, List<Object> scopes) {
+  public IndentWriter iterate(Iteration iteration, IndentWriter writer, Object object, List<Object> scopes) {
     if (object == null) return writer;
     if (object instanceof Boolean) {
       if (!(Boolean) object) {

--- a/compiler/src/main/java/com/github/mustachejava/util/AbstractIndentWriter.java
+++ b/compiler/src/main/java/com/github/mustachejava/util/AbstractIndentWriter.java
@@ -1,0 +1,41 @@
+package com.github.mustachejava.util;
+
+import java.io.IOException;
+
+public abstract class AbstractIndentWriter extends IndentWriter {
+    protected final IndentWriter inner;
+
+    public AbstractIndentWriter(IndentWriter inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public void writeLines(char[][] lines) throws IOException {
+        inner.writeLines(lines);
+    }
+
+    @Override
+    public void flushIndent() throws IOException {
+        inner.flushIndent();
+    }
+
+    @Override
+    public void setPrependIndent() {
+        inner.setPrependIndent();
+    }
+
+    @Override
+    public void write(char[] chars, int i, int i1) throws IOException {
+        inner.write(chars, i, i1);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        inner.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        inner.close();
+    }
+}

--- a/compiler/src/main/java/com/github/mustachejava/util/BaseIndentWriter.java
+++ b/compiler/src/main/java/com/github/mustachejava/util/BaseIndentWriter.java
@@ -1,0 +1,45 @@
+package com.github.mustachejava.util;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class BaseIndentWriter extends IndentWriter {
+
+  public final Writer inner;
+
+  public BaseIndentWriter(Writer inner) {
+    this.inner = inner;
+  }
+
+  @Override
+  public void writeLines(char[][] lines) throws IOException {
+    for (int i = 0; i < lines.length - 1; ++i) {
+      write(lines[i], 0, lines[i].length);
+      write('\n');
+    }
+    write(lines[lines.length - 1], 0, lines[lines.length - 1].length);
+  }
+
+  @Override
+  public void flushIndent() {
+  }
+
+  @Override
+  public void setPrependIndent() {
+  }
+
+  @Override
+  public void write(char[] chars, int i, int i1) throws IOException {
+    inner.write(chars, i, i1);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    inner.flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    inner.close();
+  }
+}

--- a/compiler/src/main/java/com/github/mustachejava/util/CapturingMustacheVisitor.java
+++ b/compiler/src/main/java/com/github/mustachejava/util/CapturingMustacheVisitor.java
@@ -54,16 +54,16 @@ public class CapturingMustacheVisitor extends DefaultMustacheVisitor {
     list.add(new IterableCode(tc, df, mustache, variable) {
 
       @Override
-      public Writer execute(Writer writer, List<Object> scopes) {
-        Writer execute = super.execute(writer, scopes);
+      public IndentWriter execute(IndentWriter writer, List<Object> scopes) {
+        IndentWriter execute = super.execute(writer, scopes);
         captured.arrayEnd();
         return execute;
       }
 
       @Override
-      public Writer next(Writer writer, Object next, List<Object> scopes) {
+      public IndentWriter next(IndentWriter writer, Object next, List<Object> scopes) {
         captured.objectStart();
-        Writer nextObject = super.next(writer, next, scopes);
+        IndentWriter nextObject = super.next(writer, next, scopes);
         captured.objectEnd();
         return nextObject;
       }
@@ -83,14 +83,14 @@ public class CapturingMustacheVisitor extends DefaultMustacheVisitor {
       boolean called;
 
       @Override
-      public Writer next(Writer writer, Object object, List<Object> scopes) {
+      public IndentWriter next(IndentWriter writer, Object object, List<Object> scopes) {
         called = true;
         return super.next(writer, object, scopes);
       }
 
       @Override
-      public Writer execute(Writer writer, List<Object> scopes) {
-        Writer execute = super.execute(writer, scopes);
+      public IndentWriter execute(IndentWriter writer, List<Object> scopes) {
+        IndentWriter execute = super.execute(writer, scopes);
         if (called) {
           captured.arrayStart(name);
           captured.arrayEnd();

--- a/compiler/src/main/java/com/github/mustachejava/util/IndentWriter.java
+++ b/compiler/src/main/java/com/github/mustachejava/util/IndentWriter.java
@@ -1,0 +1,57 @@
+package com.github.mustachejava.util;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class IndentWriter extends Writer {
+
+  public final Writer inner;
+  private final String indent;
+  private boolean prependIndent = false;
+
+  public IndentWriter(Writer inner, String indent) {
+    this.inner = inner;
+    this.indent = indent;
+  }
+
+  @Override
+  public void write(char[] chars, int off, int len) throws IOException {
+    int newOff = off;
+    for (int i = newOff; i < len; ++i) {
+      if (chars[i] == '\n') {
+        // write character up to newline
+        writeLine(chars, newOff, i + 1 - newOff);
+        this.prependIndent = true;
+
+        newOff = i + 1;
+      }
+    }
+    writeLine(chars, newOff, len - (newOff - off));
+  }
+
+  public void flushIndent() throws IOException {
+    if (this.prependIndent) {
+      inner.append(indent);
+      this.prependIndent = false;
+    }
+  }
+
+  private void writeLine(char[] chars, int off, int len) throws IOException {
+    if (len <= 0) {
+      return;
+    }
+
+    this.flushIndent();
+    inner.write(chars, off, len);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    inner.flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    inner.close();
+  }
+}

--- a/compiler/src/main/java/com/github/mustachejava/util/IndentWriter.java
+++ b/compiler/src/main/java/com/github/mustachejava/util/IndentWriter.java
@@ -3,55 +3,8 @@ package com.github.mustachejava.util;
 import java.io.IOException;
 import java.io.Writer;
 
-public class IndentWriter extends Writer {
-
-  public final Writer inner;
-  private final String indent;
-  private boolean prependIndent = false;
-
-  public IndentWriter(Writer inner, String indent) {
-    this.inner = inner;
-    this.indent = indent;
-  }
-
-  @Override
-  public void write(char[] chars, int off, int len) throws IOException {
-    int newOff = off;
-    for (int i = newOff; i < len; ++i) {
-      if (chars[i] == '\n') {
-        // write character up to newline
-        writeLine(chars, newOff, i + 1 - newOff);
-        this.prependIndent = true;
-
-        newOff = i + 1;
-      }
-    }
-    writeLine(chars, newOff, len - (newOff - off));
-  }
-
-  public void flushIndent() throws IOException {
-    if (this.prependIndent) {
-      inner.append(indent);
-      this.prependIndent = false;
-    }
-  }
-
-  private void writeLine(char[] chars, int off, int len) throws IOException {
-    if (len <= 0) {
-      return;
-    }
-
-    this.flushIndent();
-    inner.write(chars, off, len);
-  }
-
-  @Override
-  public void flush() throws IOException {
-    inner.flush();
-  }
-
-  @Override
-  public void close() throws IOException {
-    inner.close();
-  }
+public abstract class IndentWriter extends Writer {
+  public abstract void writeLines(char[][] lines) throws IOException;
+  public abstract void flushIndent() throws IOException;
+  public abstract void setPrependIndent();
 }

--- a/compiler/src/main/java/com/github/mustachejava/util/InnerIndentWriter.java
+++ b/compiler/src/main/java/com/github/mustachejava/util/InnerIndentWriter.java
@@ -1,0 +1,49 @@
+package com.github.mustachejava.util;
+
+import java.io.IOException;
+
+public class InnerIndentWriter extends AbstractIndentWriter {
+
+  private final char[] indent;
+  private boolean prependIndent = false;
+
+  public InnerIndentWriter(IndentWriter inner, char[] indent) {
+    super(inner);
+    this.indent = indent;
+  }
+
+  @Override
+  public void write(char[] chars, int off, int len) throws IOException {
+    if (len <= 0) {
+      return;
+    }
+
+    this.flushIndent();
+    super.write(chars, off, len);
+  }
+
+  @Override
+  public void writeLines(char[][] lines) throws IOException {
+    for (int i = 0; i < lines.length - 1; ++i) {
+      write(lines[i], 0, lines[i].length);
+      write('\n');
+      this.prependIndent = true;
+    }
+    write(lines[lines.length - 1], 0, lines[lines.length - 1].length);
+  }
+
+  @Override
+  public void flushIndent() throws IOException {
+    super.setPrependIndent();
+    if (this.prependIndent) {
+      this.prependIndent = false;
+      write(indent);
+    }
+  }
+
+  @Override
+  public void setPrependIndent() {
+    super.setPrependIndent();
+    this.prependIndent = true;
+  }
+}

--- a/compiler/src/test/java/com/github/mustachejava/FullSpecTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/FullSpecTest.java
@@ -1,0 +1,24 @@
+package com.github.mustachejava;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.Reader;
+import java.io.StringReader;
+
+public class FullSpecTest extends SpecTest {
+  @Override
+  protected DefaultMustacheFactory createMustacheFactory(final JsonNode test) {
+    return new SpecMustacheFactory("/spec/specs") {
+      @Override
+      public Reader getReader(String resourceName) {
+        JsonNode partial = test.get("partials").get(resourceName);
+        return new StringReader(partial == null ? "" : partial.asText());
+      }
+    };
+  }
+
+  @Override
+  protected String transformOutput(String output) {
+    return output;
+  }
+}

--- a/compiler/src/test/java/com/github/mustachejava/FullSpecTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/FullSpecTest.java
@@ -1,11 +1,43 @@
 package com.github.mustachejava;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.io.Reader;
 import java.io.StringReader;
 
 public class FullSpecTest extends SpecTest {
+  @Override
+  @Test
+  @Ignore("not ready yet")
+  public void interpolations() {
+  }
+
+  @Override
+  @Test
+  @Ignore("not ready yet")
+  public void sections() {
+  }
+
+  @Override
+  @Test
+  @Ignore("not ready yet")
+  public void delimiters() {
+  }
+
+  @Override
+  @Test
+  @Ignore("not ready yet")
+  public void inverted() {
+  }
+
+  @Override
+  @Test
+  @Ignore("not ready yet")
+  public void lambdas() {
+  }
+
   @Override
   protected DefaultMustacheFactory createMustacheFactory(final JsonNode test) {
     return new SpecMustacheFactory("/spec/specs") {

--- a/compiler/src/test/java/com/github/mustachejava/FullSpecTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/FullSpecTest.java
@@ -1,43 +1,11 @@
 package com.github.mustachejava;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import java.io.Reader;
 import java.io.StringReader;
 
 public class FullSpecTest extends SpecTest {
-  @Override
-  @Test
-  @Ignore("not ready yet")
-  public void interpolations() {
-  }
-
-  @Override
-  @Test
-  @Ignore("not ready yet")
-  public void sections() {
-  }
-
-  @Override
-  @Test
-  @Ignore("not ready yet")
-  public void delimiters() {
-  }
-
-  @Override
-  @Test
-  @Ignore("not ready yet")
-  public void inverted() {
-  }
-
-  @Override
-  @Test
-  @Ignore("not ready yet")
-  public void lambdas() {
-  }
-
   @Override
   protected DefaultMustacheFactory createMustacheFactory(final JsonNode test) {
     return new SpecMustacheFactory("/spec/specs") {

--- a/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
@@ -684,11 +684,11 @@ public class InterpreterTest extends TestCase {
       public MustacheVisitor createMustacheVisitor() {
         return new DefaultMustacheVisitor(this) {
           @Override
-          public void partial(TemplateContext tc, String variable) {
+          public void partial(TemplateContext tc, String variable, String indent) {
             if (variable.startsWith("+")) {
               // This is a dynamic partial rather than a static one
               TemplateContext partialTC = new TemplateContext("{{", "}}", tc.file(), tc.line(), tc.startOfLine());
-              list.add(new PartialCode(partialTC, df, variable.substring(1).trim()) {
+              list.add(new PartialCode(partialTC, df, variable.substring(1).trim(), indent) {
                 @Override
                 public synchronized void init() {
                   filterText();
@@ -713,7 +713,7 @@ public class InterpreterTest extends TestCase {
                 }
               });
             } else {
-              super.partial(tc, variable);
+              super.partial(tc, variable, indent);
             }
           }
         };
@@ -1222,9 +1222,9 @@ public class InterpreterTest extends TestCase {
       public MustacheVisitor createMustacheVisitor() {
         return new DefaultMustacheVisitor(this) {
           @Override
-          public void partial(TemplateContext tc, String variable) {
+          public void partial(TemplateContext tc, String variable, String indent) {
             TemplateContext partialTC = new TemplateContext("{{", "}}", tc.file(), tc.line(), tc.startOfLine());
-            list.add(new PartialCode(partialTC, df, variable) {
+            list.add(new PartialCode(partialTC, df, variable, indent) {
               @Override
               protected String partialName() {
                 return name;

--- a/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
@@ -688,7 +688,7 @@ public class InterpreterTest extends TestCase {
             if (variable.startsWith("+")) {
               // This is a dynamic partial rather than a static one
               TemplateContext partialTC = new TemplateContext("{{", "}}", tc.file(), tc.line(), tc.startOfLine());
-              list.add(new PartialCode(partialTC, df, variable.substring(1).trim(), indent) {
+              list.add(new PartialCode(partialTC, df, variable.substring(1).trim()) {
                 @Override
                 public synchronized void init() {
                   filterText();
@@ -1224,7 +1224,7 @@ public class InterpreterTest extends TestCase {
           @Override
           public void partial(TemplateContext tc, String variable, String indent) {
             TemplateContext partialTC = new TemplateContext("{{", "}}", tc.file(), tc.line(), tc.startOfLine());
-            list.add(new PartialCode(partialTC, df, variable, indent) {
+            list.add(new PartialCode(partialTC, df, variable) {
               @Override
               protected String partialName() {
                 return name;

--- a/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
@@ -17,6 +17,7 @@ import com.github.mustachejava.reflect.ReflectionObjectHandler;
 import com.github.mustachejava.reflect.SimpleObjectHandler;
 import com.github.mustachejava.resolver.DefaultResolver;
 import com.github.mustachejava.util.CapturingMustacheVisitor;
+import com.github.mustachejava.util.IndentWriter;
 import com.github.mustachejavabenchmarks.JsonCapturer;
 import com.github.mustachejavabenchmarks.JsonInterpreterTest;
 import com.google.common.collect.ImmutableMap;
@@ -503,7 +504,7 @@ public class InterpreterTest extends TestCase {
     DefaultMustacheFactory c = createMustacheFactory();
     c.setObjectHandler(new ReflectionObjectHandler() {
       @Override
-      public Writer falsey(Iteration iteration, Writer writer, Object object, List<Object> scopes) {
+      public IndentWriter falsey(Iteration iteration, IndentWriter writer, Object object, List<Object> scopes) {
         if (object instanceof Number) {
           if (((Number) object).intValue() == 0) {
             return iteration.next(writer, object, scopes);
@@ -513,7 +514,7 @@ public class InterpreterTest extends TestCase {
       }
 
       @Override
-      public Writer iterate(Iteration iteration, Writer writer, Object object, List<Object> scopes) {
+      public IndentWriter iterate(Iteration iteration, IndentWriter writer, Object object, List<Object> scopes) {
         if (object instanceof Number) {
           if (((Number) object).intValue() == 0) {
             return writer;
@@ -703,12 +704,12 @@ public class InterpreterTest extends TestCase {
                 ConcurrentMap<String, Mustache> dynamicaPartialCache = new ConcurrentHashMap<>();
 
                 @Override
-                public Writer execute(Writer writer, List<Object> scopes) {
+                public IndentWriter execute(IndentWriter writer, List<Object> scopes) {
                   // Calculate the name of the dynamic partial
                   StringWriter sw = new StringWriter();
                   partial.execute(sw, scopes);
                   Mustache mustache = dynamicaPartialCache.computeIfAbsent(sw.toString(), df::compilePartial);
-                  Writer execute = mustache.execute(writer, scopes);
+                  IndentWriter execute = mustache.execute(writer, scopes);
                   return appendText(execute);
                 }
               });
@@ -1362,7 +1363,7 @@ public class InterpreterTest extends TestCase {
             list.add(new IterableCode(templateContext, df, mustache, variable) {
               Binding binding = oh.createBinding("params", templateContext, this);
 
-              protected Writer handleFunction(Writer writer, Function function, List<Object> scopes) {
+              protected IndentWriter handleFunction(IndentWriter writer, Function function, List<Object> scopes) {
                 boolean added = addScope(scopes, binding.get(scopes));
                 try {
                   return super.handleFunction(writer, function, scopes);
@@ -1401,7 +1402,7 @@ public class InterpreterTest extends TestCase {
           public void value(TemplateContext tc, String variable, boolean encoded) {
             list.add(new ValueCode(tc, df, variable, encoded) {
               @Override
-              public Writer execute(Writer writer, List<Object> scopes) {
+              public IndentWriter execute(IndentWriter writer, List<Object> scopes) {
                 try {
                   final Object object = get(scopes);
                   if (object != null) {
@@ -1515,7 +1516,7 @@ public class InterpreterTest extends TestCase {
           public void value(TemplateContext tc, String variable, boolean encoded) {
             list.add(new ValueCode(tc, df, variable, encoded) {
               @Override
-              public Writer execute(Writer writer, List<Object> scopes) {
+              public IndentWriter execute(IndentWriter writer, List<Object> scopes) {
                 try {
                   final Object object = get(scopes);
                   if (object == null) {

--- a/compiler/src/test/java/com/github/mustachejava/SpecTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/SpecTest.java
@@ -157,7 +157,7 @@ public class SpecTest {
           }
         } else {
           System.out.println(": failed!");
-          System.out.println(expected.replace("\n", "\\n").replace("\r", "\\r") + " != " + writer.toString().replace("\n", "\\n").replace("\r", "\\r"));
+          System.out.println(expected + " !=" + writer.toString());
           System.out.println(test);
           failed = true;
         }

--- a/compiler/src/test/java/com/github/mustachejava/SpecTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/SpecTest.java
@@ -157,7 +157,7 @@ public class SpecTest {
           }
         } else {
           System.out.println(": failed!");
-          System.out.println(expected + " != " + writer.toString());
+          System.out.println(expected.replace("\n", "\\n").replace("\r", "\\r") + " != " + writer.toString().replace("\n", "\\n").replace("\r", "\\r"));
           System.out.println(test);
           failed = true;
         }

--- a/compiler/src/test/java/com/github/mustachejava/SpecTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/SpecTest.java
@@ -157,7 +157,7 @@ public class SpecTest {
           }
         } else {
           System.out.println(": failed!");
-          System.out.println(expected + " !=" + writer.toString());
+          System.out.println(expected + " != " + writer.toString());
           System.out.println(test);
           failed = true;
         }

--- a/compiler/src/test/java/com/github/mustachejava/SpecTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/SpecTest.java
@@ -147,7 +147,7 @@ public class SpecTest {
         StringWriter writer = new StringWriter();
         compile.execute(writer, new Object[]{new ObjectMapper().readValue(data.toString(), Map.class), functionMap.get(file)});
         String expected = test.get("expected").asText();
-        if (writer.toString().replaceAll("\\s+", "").equals(expected.replaceAll("\\s+", ""))) {
+        if (transformOutput(writer.toString()).equals(transformOutput(expected))) {
           System.out.print(": success");
           if (writer.toString().equals(expected)) {
             System.out.println("!");
@@ -172,6 +172,10 @@ public class SpecTest {
     }
     System.out.println("Success: " + success + " Whitespace: " + whitespace + " Fail: " + fail);
     assertFalse(fail > 0);
+  }
+
+  protected String transformOutput(String output) {
+    return output.replaceAll("\\s+", "");
   }
 
   protected DefaultMustacheFactory createMustacheFactory(final JsonNode test) {


### PR DESCRIPTION
I implemented an alternative approach that avoids reparsing the output for newlines in the `IndentWriter`.

Basic idea was to use a specialized `IndentWriter` everywhere. This way, we can call the newline-specialized method `writeLines` in `appendText`.

Note however, that besides changing a *lot* of interfaces this implementation made the implementation of the `LatchedWriter` a lot more complicated because it also needs to be newline aware in its buffer.