### PR TITLE
use java 7 exception constructor to avoid filling stacktrace

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/reflect/GuardedWrapper.java
+++ b/compiler/src/main/java/com/github/mustachejava/reflect/GuardedWrapper.java
@@ -17,10 +17,6 @@ public class GuardedWrapper implements Wrapper {
   @SuppressWarnings("ThrowableInstanceNeverThrown")
   protected static final GuardException guardException = new GuardException();
 
-  static {
-    guardException.setStackTrace(new StackTraceElement[0]);
-  }
-
   // Array of guards that must be satisfied
   protected final Guard[] guards;
 

--- a/compiler/src/main/java/com/github/mustachejava/util/GuardException.java
+++ b/compiler/src/main/java/com/github/mustachejava/util/GuardException.java
@@ -6,9 +6,10 @@ package com.github.mustachejava.util;
  */
 public class GuardException extends RuntimeException {
   public GuardException() {
+    super(null, null, false, false);
   }
 
   public GuardException(String message) {
-    super(message);
+    super(message, null, false, false);
   }
 }


### PR DESCRIPTION
This change uses the four parameter constructor of Throwable in order to avoid filling the stacktrace. This is required, because the `guardException.setStackTrace(new StackTraceElement[0]);` seams to be not enough to avoid classloader leaks.