### PR TITLE
scala2.13.5_fix:  Fixed a number of deprecation issues related to Sca…

### DIFF
--- a/scala-extensions/scala-extensions-2.13/build.sbt
+++ b/scala-extensions/scala-extensions-2.13/build.sbt
@@ -2,9 +2,19 @@ lazy val `scala-extensions-2-13` = project
   .in(file("."))
   .settings(
     resolvers += Resolver.mavenLocal,
-    scalaVersion := "2.13.0",
+    scalaVersion := "2.13.5",
     libraryDependencies ++= Seq(
-      "com.github.spullara.mustache.java" % "compiler" % "0.8.17-SNAPSHOT",
-      "junit" % "junit" % "4.8.2" % "test"
+      "com.github.spullara.mustache.java" % "compiler" % "0.9.7",
+      "junit" % "junit" % "4.8.2" % "test",
+
+      "com.novocode" % "junit-interface" % "0.11" % "test"
+        exclude("junit", "junit-dep")
+
+    ),
+    scalacOptions ++= Seq(
+      "-feature",
+      "-deprecation",
+      "-unchecked",
+      "-language:reflectiveCalls"
     )
   )

--- a/scala-extensions/scala-extensions-2.13/project/build.properties
+++ b/scala-extensions/scala-extensions-2.13/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.7

--- a/scala-extensions/scala-extensions-2.13/src/main/scala/com/twitter/mustache/ScalaObjectHandler.scala
+++ b/scala-extensions/scala-extensions-2.13/src/main/scala/com/twitter/mustache/ScalaObjectHandler.scala
@@ -14,9 +14,9 @@ import scala.reflect.ClassTag
 class ScalaObjectHandler extends ReflectionObjectHandler {
 
   // Allow any method or field
-  override def checkMethod(member: Method) {}
+  override def checkMethod(member: Method):Unit = {}
 
-  override def checkField(member: Field) {}
+  override def checkField(member: Field):Unit = {}
 
   override def coerce(value: AnyRef) = {
     value match {
@@ -30,7 +30,7 @@ class ScalaObjectHandler extends ReflectionObjectHandler {
 
   override def iterate(iteration: Iteration, writer: Writer, value: AnyRef, scopes: java.util.List[AnyRef]) = {
     value match {
-      case TraversableAnyRef(t) => {
+      case IterableAnyRef(t) => {
         var newWriter = writer
         t foreach {
           next =>
@@ -45,7 +45,7 @@ class ScalaObjectHandler extends ReflectionObjectHandler {
 
   override def falsey(iteration: Iteration, writer: Writer, value: AnyRef, scopes: java.util.List[AnyRef]) = {
     value match {
-      case TraversableAnyRef(t) => {
+      case IterableAnyRef(t) => {
         if (t.isEmpty) {
           iteration.next(writer, value, scopes)
         } else {
@@ -57,7 +57,7 @@ class ScalaObjectHandler extends ReflectionObjectHandler {
     }
   }
 
-  val TraversableAnyRef = new Def[Traversable[AnyRef]]
+  val IterableAnyRef = new Def[Iterable[AnyRef]]
   class Def[C: ClassTag] {
     def unapply[X: ClassTag](x: X): Option[C] = {
       x match {

--- a/scala-extensions/scala-extensions-2.13/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
+++ b/scala-extensions/scala-extensions-2.13/src/test/scala/com/twitter/mustache/ObjectHandlerTest.scala
@@ -9,7 +9,7 @@ import org.junit.{Assert, Test}
 class ObjectHandlerTest {
 
   @Test
-  def testMap() {
+  def testMap():Unit = {
     val mf = new DefaultMustacheFactory()
     mf.setObjectHandler(new ScalaObjectHandler)
     val m = mf.compile(
@@ -22,7 +22,7 @@ class ObjectHandlerTest {
   }
 
   @Test
-  def testScalaHandler() {
+  def testScalaHandler():Unit = {
     val pool = Executors.newCachedThreadPool()
     val mf = new DefaultMustacheFactory()
     mf.setObjectHandler(new ScalaObjectHandler)
@@ -58,7 +58,7 @@ class ObjectHandlerTest {
   }
 
   @Test
-  def testScalaStream() {
+  def testScalaStream():Unit = {
     val pool = Executors.newCachedThreadPool()
     val mf = new DefaultMustacheFactory()
     mf.setObjectHandler(new ScalaObjectHandler)
@@ -66,7 +66,7 @@ class ObjectHandlerTest {
     val m = mf.compile(new StringReader("{{#stream}}{{value}}{{/stream}}"), "helloworld")
     val sw = new StringWriter
     val writer = m.execute(sw, new {
-      val stream = Stream(
+      val stream = LazyList(
         new { val value = "hello" },
         new { val value = "world" })
     })
@@ -75,7 +75,7 @@ class ObjectHandlerTest {
   }
 
   @Test
-  def testUnit() {
+  def testUnit():Unit = {
     val mf = new DefaultMustacheFactory()
     mf.setObjectHandler(new ScalaObjectHandler)
     val m = mf.compile(new StringReader("{{test}}"), "unit")
@@ -87,7 +87,7 @@ class ObjectHandlerTest {
   }
 
   @Test
-  def testOptions() {
+  def testOptions():Unit = {
     val mf = new DefaultMustacheFactory()
     mf.setObjectHandler(new ScalaObjectHandler)
     val m = mf.compile(new StringReader("{{foo}}{{bar}}"), "unit")
@@ -100,7 +100,7 @@ class ObjectHandlerTest {
   }
 
   @Test
-  def testClass() {
+  def testClass():Unit = {
     val mf = new DefaultMustacheFactory()
     mf.setObjectHandler(new ScalaObjectHandler)
     val m = mf.compile(
@@ -116,7 +116,7 @@ class ObjectHandlerTest {
   }
 
   @Test
-  def testClassDot() {
+  def testClassDot():Unit = {
     val mf = new DefaultMustacheFactory()
     mf.setObjectHandler(new ScalaObjectHandler)
     val m = mf.compile(


### PR DESCRIPTION
…la 2.13.x:

-- Replaced Traversable with Iterable
-- Added ":Unit = " to a number of methods
-- Replaced Stream with LazyList
-- Updated build.sbt with compiler options, interface to run the JUnit tests, updated library dependencies, updated scala version.