### PR TITLE
Add FileSystemResolver(Path) constructor

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/resolver/FileSystemResolver.java
+++ b/compiler/src/main/java/com/github/mustachejava/resolver/FileSystemResolver.java
@@ -1,9 +1,13 @@
 package com.github.mustachejava.resolver;
 
-import com.github.mustachejava.MustacheException;
-import com.github.mustachejava.MustacheResolver;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+
+import com.github.mustachejava.MustacheException;
+import com.github.mustachejava.MustacheResolver;
 
 /**
  * MustacheResolver implementation that resolves
@@ -12,9 +16,11 @@ import java.nio.charset.StandardCharsets;
 public class FileSystemResolver implements MustacheResolver {
 
   private final File fileRoot;
+  private final Path pathRoot;
 
   public FileSystemResolver() {
     this.fileRoot = null;
+    this.pathRoot = null;
   }
 
   /**
@@ -30,10 +36,36 @@ public class FileSystemResolver implements MustacheResolver {
       throw new MustacheException(fileRoot + " is not a directory");
     }
     this.fileRoot = fileRoot;
+    this.pathRoot = null;
+  }
+
+  /**
+   * Use the file system to resolve mustache templates.
+   *
+   * @param pathRoot where in the file system to find the templates
+   */
+  public FileSystemResolver(Path pathRoot) {
+    // This is not exactly the same as FileSystemResolver(pathRoot.toFile()).
+    // pathRoot.toFile() throws UnsupportedOperationException when
+    // pathRoot.getFileSystem() is not the default file system.
+    //
+    // The other constructors could be rewritten to delegate to this one, but
+    // that would risk changing existing behavior more than this approach does.
+    if (!Files.exists(pathRoot)) {
+      throw new MustacheException(pathRoot + " does not exist");
+    }
+    if (!Files.isDirectory(pathRoot)) {
+      throw new MustacheException(pathRoot + " is not a directory");
+    }
+    this.fileRoot = null;
+    this.pathRoot = pathRoot;
   }
 
   @Override
   public Reader getReader(String resourceName) {
+    if (pathRoot != null) {
+      return getReaderFromPath(resourceName);
+    }
     InputStream is = null;
     File file = fileRoot == null ? new File(resourceName) : new File(fileRoot, resourceName);
     if (file.exists() && file.isFile()) {
@@ -58,6 +90,32 @@ public class FileSystemResolver implements MustacheResolver {
       return new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
     } else {
       return null;
+    }
+  }
+
+  private Reader getReaderFromPath(String resourceName) {
+    Path file;
+    try {
+      // Intentionally avoid using pathRoot.resolve(resourceName), which behaves
+      // differently than our java.io.File code when resourceName is an
+      // absolute path.
+      file = pathRoot.getFileSystem().getPath(pathRoot.toString(), resourceName);
+    } catch (InvalidPathException ignored) {
+      // Mimic the java.io.File behavior for invalid resourceName paths.
+      return null;
+    }
+    if (!Files.isRegularFile(file)) {
+      return null;
+    }
+    try {
+      Path canonicalFile = file.toRealPath();
+      Path canonicalRoot = pathRoot.toRealPath();
+      if (!canonicalFile.startsWith(canonicalRoot)) {
+        throw new MustacheException("File not under root, file=" + canonicalFile + ", root=" + canonicalRoot);
+      }
+      return Files.newBufferedReader(file);
+    } catch (IOException e) {
+      throw new MustacheException("Found file, could not open: " + file, e);
     }
   }
 }

--- a/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
@@ -14,43 +14,49 @@ public class ClasspathResolverTest {
     @Test
     public void getReaderNullRootAndResourceHasRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver();
-        Reader reader = underTest.getReader("nested_partials_template.html");
-        assertThat(reader, is(notNullValue()));
+        try (Reader reader = underTest.getReader("nested_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
     }
 
     @Test
     public void getReaderWithRootAndResourceHasRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
-        Reader reader = underTest.getReader("absolute_partials_template.html");
-        assertThat(reader, is(notNullValue()));
+        try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
     }
 
     @Test
     public void getReaderWithRootThatHasTrailingForwardSlashAndResourceHasRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates/");
-        Reader reader = underTest.getReader("absolute_partials_template.html");
-        assertThat(reader, is(notNullValue()));
+        try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
     }
 
     @Test
     public void getReaderWithRootAndResourceHasAbsolutePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
-        Reader reader = underTest.getReader("/absolute_partials_template.html");
-        assertThat(reader, is(notNullValue()));
+        try (Reader reader = underTest.getReader("/absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
     }
 
     @Test
     public void getReaderWithRootThatHasTrailingForwardSlashAndResourceHasAbsolutePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates/");
-        Reader reader = underTest.getReader("/absolute_partials_template.html");
-        assertThat(reader, is(notNullValue()));
+        try (Reader reader = underTest.getReader("/absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
     }
 
     @Test
     public void getReaderNullRootDoesNotFindFileWithAbsolutePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver();
-        Reader reader = underTest.getReader("/nested_partials_template.html");
-        assertThat(reader, is(nullValue()));
+        try (Reader reader = underTest.getReader("/nested_partials_template.html")) {
+            assertThat(reader, is(nullValue()));
+        }
     }
 
     @Test (expected = NullPointerException.class)
@@ -68,14 +74,57 @@ public class ClasspathResolverTest {
     @Test
     public void getReaderWithRootAndResourceHasDoubleDotRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
-        Reader reader = underTest.getReader("absolute/../absolute_partials_template.html");
-        assertThat(reader, is(notNullValue()));
+        try (Reader reader = underTest.getReader("absolute/../absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
     }
 
     @Test
     public void getReaderWithRootAndResourceHasDotRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
-        Reader reader = underTest.getReader("absolute/./nested_partials_sub.html");
-        assertThat(reader, is(notNullValue()));
+        try (Reader reader = underTest.getReader("absolute/./nested_partials_sub.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    // questionable: different than FileSystemResolver
+    @Test (expected = IllegalArgumentException.class)
+    public void getReaderNullRootAndResourceHasInvalidPathThrows() throws Exception {
+        ClasspathResolver underTest = new ClasspathResolver();
+        underTest.getReader("\0");
+    }
+
+    // questionable: different than FileSystemResolver
+    @Test (expected = IllegalArgumentException.class)
+    public void getReaderWithRootAndResourceHasInvalidPathThrows() throws Exception {
+        ClasspathResolver underTest = new ClasspathResolver("templates");
+        underTest.getReader("\0");
+    }
+
+    // questionable: probably unintended behavior
+    @Test
+    public void getReaderNullRootAndResourceIsDirectory() throws Exception {
+        ClasspathResolver underTest = new ClasspathResolver();
+        try (Reader reader = underTest.getReader("templates/absolute")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    // questionable: probably unintended behavior
+    @Test
+    public void getReaderWithRootAndResourceIsDirectory() throws Exception {
+        ClasspathResolver underTest = new ClasspathResolver("templates");
+        try (Reader reader = underTest.getReader("absolute")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    // questionable: different than FileSystemResolver
+    @Test
+    public void getReaderWithRootAndResourceAboveRoot() throws Exception {
+        ClasspathResolver underTest = new ClasspathResolver("templates/absolute");
+        try (Reader reader = underTest.getReader("../absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
     }
 }

--- a/compiler/src/test/java/com/github/mustachejava/resolver/FileSystemResolverTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/resolver/FileSystemResolverTest.java
@@ -1,0 +1,252 @@
+package com.github.mustachejava.resolver;
+
+import com.github.mustachejava.MustacheException;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.Reader;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class FileSystemResolverTest {
+
+    private static String resources = "src/test/resources";
+
+    @Test
+    public void getReaderDefaultRootAndResourceHasRelativePath() throws Exception {
+        FileSystemResolver underTest = new FileSystemResolver();
+        try (Reader reader = underTest.getReader(resources + "/nested_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderFileRootAndResourceHasRelativePath() throws Exception {
+        File fileRoot = new File(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(fileRoot);
+        try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderPathRootAndResourceHasRelativePath() throws Exception {
+        Path pathRoot = Paths.get(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+        try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderDefaultRootDoesNotFindFileWithAbsolutePath() throws Exception {
+        FileSystemResolver underTest = new FileSystemResolver();
+        try (Reader reader = underTest.getReader("/" + resources + "/nested_partials_template.html")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderFileRootAndResourceHasAbsolutePath() throws Exception {
+        File fileRoot = new File(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(fileRoot);
+        try (Reader reader = underTest.getReader("/absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderPathRootAndResourceHasAbsolutePath() throws Exception {
+        Path pathRoot = Paths.get(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+        try (Reader reader = underTest.getReader("/absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void getReaderDefaultRootAndNullResourceThrowsNullPointer() throws Exception {
+        FileSystemResolver underTest = new FileSystemResolver();
+        underTest.getReader(null);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void getReaderFileRootAndNullResourceThrowsNullPointer() throws Exception {
+        File fileRoot = new File(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(fileRoot);
+        underTest.getReader(null);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void getReaderPathRootAndNullResourceThrowsNullPointer() throws Exception {
+        Path pathRoot = Paths.get(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+        underTest.getReader(null);
+    }
+
+    @Test
+    public void getReaderDefaultRootAndResourceHasDoubleDotRelativePath() throws Exception {
+        FileSystemResolver underTest = new FileSystemResolver();
+        try (Reader reader = underTest.getReader(resources + "/templates_filepath/../nested_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderFileRootAndResourceHasDoubleDotRelativePath() throws Exception {
+        File fileRoot = new File(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(fileRoot);
+        try (Reader reader = underTest.getReader("absolute/../absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderPathRootAndResourceHasDoubleDotRelativePath() throws Exception {
+        Path pathRoot = Paths.get(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+        try (Reader reader = underTest.getReader("absolute/../absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderDefaultRootAndResourceHasDotRelativePath() throws Exception {
+        FileSystemResolver underTest = new FileSystemResolver();
+        try (Reader reader = underTest.getReader(resources + "/templates_filepath/./absolute_partials_template.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderFileRootAndResourceHasDotRelativePath() throws Exception {
+        File fileRoot = new File(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(fileRoot);
+        try (Reader reader = underTest.getReader("absolute/./nested_partials_sub.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderPathRootAndResourceHasDotRelativePath() throws Exception {
+        Path pathRoot = Paths.get(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+        try (Reader reader = underTest.getReader("absolute/./nested_partials_sub.html")) {
+            assertThat(reader, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderDefaultRootAndResourceHasInvalidPath() throws Exception {
+        FileSystemResolver underTest = new FileSystemResolver();
+        try (Reader reader = underTest.getReader("\0")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderFileRootAndResourceHasInvalidPath() throws Exception {
+        File fileRoot = new File(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(fileRoot);
+        try (Reader reader = underTest.getReader("\0")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderPathRootAndResourceHasInvalidPath() throws Exception {
+        Path pathRoot = Paths.get(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+        try (Reader reader = underTest.getReader("\0")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderPathRootAndNonDefaultFileSystem() throws Exception {
+        Path zipFile = Paths.get(resources + "/templates.jar");
+        try (FileSystem zipFileSystem = FileSystems.newFileSystem(zipFile, null)) {
+            Path pathRoot = zipFileSystem.getPath("templates");
+            FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+            try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
+                assertThat(reader, is(notNullValue()));
+            }
+        }
+    }
+
+    @Test
+    public void getReaderDefaultRootAndResourceIsDirectory() throws Exception {
+        FileSystemResolver underTest = new FileSystemResolver();
+        try (Reader reader = underTest.getReader(resources + "/templates_filepath")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderFileRootAndResourceIsDirectory() throws Exception {
+        File fileRoot = new File(resources);
+        FileSystemResolver underTest = new FileSystemResolver(fileRoot);
+        try (Reader reader = underTest.getReader("templates_filepath")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+
+    @Test
+    public void getReaderPathRootAndResourceIsDirectory() throws Exception {
+        Path pathRoot = Paths.get(resources);
+        FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+        try (Reader reader = underTest.getReader("templates_filepath")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+
+    // questionable: all the AboveRoot tests, which expose the information of
+    //               whether the resource file exists
+
+    @Test
+    public void getReaderDefaultRootAndResourceAboveRootNotFound() throws Exception {
+        FileSystemResolver underTest = new FileSystemResolver();
+        try (Reader reader = underTest.getReader("../this_file_does_not_exist.html")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+
+    @Test (expected = MustacheException.class)
+    public void getReaderFileRootAndResourceAboveRootFound() throws Exception {
+        File fileRoot = new File(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(fileRoot);
+        underTest.getReader("../nested_partials_template.html");
+    }
+
+    @Test
+    public void getReaderFileRootAndResourceAboveRootNotFound() throws Exception {
+        File fileRoot = new File(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(fileRoot);
+        try (Reader reader = underTest.getReader("../this_file_does_not_exist.html")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+
+    @Test (expected = MustacheException.class)
+    public void getReaderPathRootAndResourceAboveRootFound() throws Exception {
+        Path pathRoot = Paths.get(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+        underTest.getReader("../nested_partials_template.html");
+    }
+
+    @Test
+    public void getReaderPathRootAndResourceAboveRootNotFound() throws Exception {
+        Path pathRoot = Paths.get(resources + "/templates_filepath");
+        FileSystemResolver underTest = new FileSystemResolver(pathRoot);
+        try (Reader reader = underTest.getReader("../this_file_does_not_exist.html")) {
+            assertThat(reader, is(nullValue()));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #223

Reopening PR#224, which was opened against the old `master` branch instead of the new `main` branch.

Make FileSystemResolver(Path) use NIO APIs underneath and support
non-default file systems, but otherwise make its observable behavior
identical to FileSystemResolver(path.toFile()), including corner cases.

Add tests demonstrating current behavior of ClasspathResolver and
FileSystemResolver, even when that behavior is questionable.