### PR TITLE
Remove guava as a dependency

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -54,12 +54,6 @@
       <version>${jackson.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>30.0-jre</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/InterpreterTest.java
@@ -14,7 +14,6 @@ import com.github.mustachejava.util.CapturingMustacheVisitor;
 import com.github.mustachejava.util.Wrapper;
 import com.github.mustachejavabenchmarks.JsonCapturer;
 import com.github.mustachejavabenchmarks.JsonInterpreterTest;
-import com.google.common.collect.ImmutableMap;
 import junit.framework.TestCase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -27,6 +26,7 @@ import java.util.function.Function;
 
 import static com.github.mustachejava.TestUtil.getContents;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 
 /**
  * Tests for the compiler.
@@ -1482,7 +1482,7 @@ public class InterpreterTest extends TestCase {
     MustacheFactory mustacheFactory = createMustacheFactory();
     Mustache mustache = mustacheFactory.compile("templates/someTemplate.mustache");
     StringWriter stringWriter = new StringWriter();
-    mustache.execute(stringWriter, ImmutableMap.of("title", "Some title!"));
+    mustache.execute(stringWriter, singletonMap("title", "Some title!"));
     assertEquals(getContents(root, "templates/someTemplate.txt"), stringWriter.toString());
   }
 


### PR DESCRIPTION
Guava was used in a test for issue [191](https://github.com/spullara/mustache.java/issues/191), but is incidental to the test, which relates to rendering of partial templates.

Replace usage of `ImmutableMap` with `singletonMap` from the JCL