### PR TITLE
Update tests for jUnit 4.x

### DIFF
--- a/compiler/src/test/java/com/github/mustachejava/AbstractClassTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/AbstractClassTest.java
@@ -3,12 +3,14 @@ package com.github.mustachejava;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class AbstractClassTest {
   static abstract class AbstractFoo {
@@ -42,12 +44,13 @@ public class AbstractClassTest {
       containers.add(new Container(new Foo()));
       containers.add(new Container(new Bar()));
       HashMap<String, Object> scopes = new HashMap<>();
-      Writer writer = new OutputStreamWriter(System.out);
+      Writer writer = new StringWriter();
       MustacheFactory mf = new DefaultMustacheFactory();
       Mustache mustache = mf.compile(new StringReader("{{#containers}} {{foo.value}} {{/containers}}"), "example");
       scopes.put("containers", containers);
       mustache.execute(writer, scopes);
       writer.flush();
+      assertEquals(" I am Foo  I am Bar ", writer.toString());
   }
 
   @Test
@@ -56,11 +59,12 @@ public class AbstractClassTest {
       containers.add(new Container(new Foo()));
       containers.add(new Container(new Bar()));
       HashMap<String, Object> scopes = new HashMap<>();
-      Writer writer = new OutputStreamWriter(System.out);
+      Writer writer = new StringWriter();
       MustacheFactory mf = new DefaultMustacheFactory();
       Mustache mustache = mf.compile(new StringReader("{{#containers}} {{#foo}}{{value}}{{/foo}} {{/containers}}"), "example");
       scopes.put("containers", containers);
       mustache.execute(writer, scopes);
       writer.flush();
+      assertEquals(" I am Foo  I am Bar ", writer.toString());
   }
 }

--- a/compiler/src/test/java/com/github/mustachejava/ArraysIndexesTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/ArraysIndexesTest.java
@@ -12,7 +12,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Shows a simple way to add indexes for arrays.
@@ -66,8 +66,8 @@ public class ArraysIndexesTest {
   }
 
   @Test
-  public void testThrowMustacheExceptionInCaseOfNullHandler() throws Exception {
-    try {
+  public void testThrowMustacheExceptionInCaseOfNullHandler() {
+    MustacheException expected = assertThrows(MustacheException.class, () -> {
       String template = "<ol>\n" +
               "    <li>{{test.1}}</li>\n" +
               "    <li>{{test.0}}</li>\n" +
@@ -79,16 +79,14 @@ public class ArraysIndexesTest {
               "{{/test}}\n" +
               "</ol>";
       Object scope = new Object() {
-        String[] test = new String[]{ "a", "b", "c", "d" };
+        String[] test = new String[]{"a", "b", "c", "d"};
       };
       DefaultMustacheFactory mf = new DefaultMustacheFactory();
       mf.setObjectHandler(null);
       Mustache m = mf.compile(new StringReader(template), "template");
       m.execute(new StringWriter(), scope).flush();
-      fail("should have thrown MustacheException");
-    } catch (MustacheException expected) {
-      assertEquals("Failed to get value for test.1 @[template:2]", expected.getMessage());
-    }
+    });
+    assertEquals("Failed to get value for test.1 @[template:2]", expected.getMessage());
   }
 
   private static class ArrayMap extends AbstractMap<Object, Object> implements Iterable<Object> {

--- a/compiler/src/test/java/com/github/mustachejava/ConcurrencyTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/ConcurrencyTest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.github.mustachejavabenchmarks.BenchmarkTest.skip;
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Inspired by an unconfirmed bug report.

--- a/compiler/src/test/java/com/github/mustachejava/ConvertMethodsToFunctionsTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/ConvertMethodsToFunctionsTest.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.function.Function;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ConvertMethodsToFunctionsTest {
 

--- a/compiler/src/test/java/com/github/mustachejava/FailOnMissingTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/FailOnMissingTest.java
@@ -6,13 +6,12 @@ import com.github.mustachejava.reflect.ReflectionObjectHandler;
 import com.github.mustachejava.util.Wrapper;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class FailOnMissingTest {
   @Test
@@ -34,7 +33,7 @@ public class FailOnMissingTest {
     };
     DefaultMustacheFactory dmf = new DefaultMustacheFactory();
     dmf.setObjectHandler(roh);
-    try {
+    MustacheException me = assertThrows(MustacheException.class, () -> {
       Mustache test = dmf.compile(new StringReader("{{test}}"), "test");
       StringWriter sw = new StringWriter();
       test.execute(sw, new Object() {
@@ -42,11 +41,7 @@ public class FailOnMissingTest {
       }).close();
       assertEquals("ok", sw.toString());
       test.execute(new StringWriter(), new Object());
-      fail("Should have failed");
-    } catch (MustacheException me) {
-      assertEquals("test not found in [test:1] @[test:1]", me.getCause().getMessage());
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    });
+    assertEquals("test not found in [test:1] @[test:1]", me.getCause().getMessage());
   }
 }

--- a/compiler/src/test/java/com/github/mustachejava/FallbackTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/FallbackTest.java
@@ -6,11 +6,10 @@ import org.junit.Test;
 import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static com.github.mustachejava.TestUtil.getContents;
-import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class FallbackTest {
 
@@ -18,7 +17,7 @@ public class FallbackTest {
   private static File rootOverride;
 
   @Test
-  public void testDefaultPage1() throws MustacheException, IOException, ExecutionException, InterruptedException {
+  public void testDefaultPage1() throws MustacheException, IOException {
     MustacheFactory c = new FallbackMustacheFactory(rootDefault, rootDefault);  // no override
     Mustache m = c.compile("page1.html");
     StringWriter sw = new StringWriter();
@@ -29,7 +28,7 @@ public class FallbackTest {
   }
 
   @Test
-  public void testOverridePage1() throws MustacheException, IOException, ExecutionException, InterruptedException {
+  public void testOverridePage1() throws MustacheException, IOException {
     MustacheFactory c = new FallbackMustacheFactory(rootOverride, rootDefault);
     Mustache m = c.compile("page1.html");
     StringWriter sw = new StringWriter();
@@ -40,7 +39,7 @@ public class FallbackTest {
   }
 
   @Test
-  public void testOverridePage2() throws MustacheException, IOException, ExecutionException, InterruptedException {
+  public void testOverridePage2() throws MustacheException, IOException {
     MustacheFactory c = new FallbackMustacheFactory(rootOverride, rootDefault);
     Mustache m = c.compile("page2.html");
     StringWriter sw = new StringWriter();
@@ -53,13 +52,11 @@ public class FallbackTest {
   @Test
   public void testMustacheNotFoundException() {
     String nonExistingMustache = "404";
-    try {
+    MustacheNotFoundException e = assertThrows(MustacheNotFoundException.class, () -> {
       MustacheFactory c = new FallbackMustacheFactory(rootOverride, rootDefault);
       c.compile(nonExistingMustache);
-      fail("Didn't throw an exception");
-    } catch (MustacheNotFoundException e) {
-      assertEquals(nonExistingMustache, e.getName());
-    }
+    });
+    assertEquals(nonExistingMustache, e.getName());
   }
 
   @BeforeClass

--- a/compiler/src/test/java/com/github/mustachejava/PreTranslateTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/PreTranslateTest.java
@@ -8,7 +8,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.function.Function;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * If you want to precompile translations, you will need to do two passes against

--- a/compiler/src/test/java/com/github/mustachejava/SpecTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/SpecTest.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Specification tests

--- a/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
@@ -4,10 +4,8 @@ import org.junit.Test;
 
 import java.io.Reader;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class ClasspathResolverTest {
 
@@ -15,7 +13,7 @@ public class ClasspathResolverTest {
     public void getReaderNullRootAndResourceHasRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver();
         try (Reader reader = underTest.getReader("nested_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -23,7 +21,7 @@ public class ClasspathResolverTest {
     public void getReaderWithRootAndResourceHasRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
         try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -31,7 +29,7 @@ public class ClasspathResolverTest {
     public void getReaderWithRootThatHasTrailingForwardSlashAndResourceHasRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates/");
         try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -39,7 +37,7 @@ public class ClasspathResolverTest {
     public void getReaderWithRootAndResourceHasAbsolutePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
         try (Reader reader = underTest.getReader("/absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -47,7 +45,7 @@ public class ClasspathResolverTest {
     public void getReaderWithRootThatHasTrailingForwardSlashAndResourceHasAbsolutePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates/");
         try (Reader reader = underTest.getReader("/absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -55,7 +53,7 @@ public class ClasspathResolverTest {
     public void getReaderNullRootDoesNotFindFileWithAbsolutePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver();
         try (Reader reader = underTest.getReader("/nested_partials_template.html")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -75,7 +73,7 @@ public class ClasspathResolverTest {
     public void getReaderWithRootAndResourceHasDoubleDotRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
         try (Reader reader = underTest.getReader("absolute/../absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -83,7 +81,7 @@ public class ClasspathResolverTest {
     public void getReaderWithRootAndResourceHasDotRelativePath() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
         try (Reader reader = underTest.getReader("absolute/./nested_partials_sub.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -106,7 +104,7 @@ public class ClasspathResolverTest {
     public void getReaderNullRootAndResourceIsDirectory() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver();
         try (Reader reader = underTest.getReader("templates/absolute")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -115,7 +113,7 @@ public class ClasspathResolverTest {
     public void getReaderWithRootAndResourceIsDirectory() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
         try (Reader reader = underTest.getReader("absolute")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -124,7 +122,7 @@ public class ClasspathResolverTest {
     public void getReaderWithRootAndResourceAboveRoot() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates/absolute");
         try (Reader reader = underTest.getReader("../absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 }

--- a/compiler/src/test/java/com/github/mustachejava/resolver/FileSystemResolverTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/resolver/FileSystemResolverTest.java
@@ -10,10 +10,8 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class FileSystemResolverTest {
 
@@ -23,7 +21,7 @@ public class FileSystemResolverTest {
     public void getReaderDefaultRootAndResourceHasRelativePath() throws Exception {
         FileSystemResolver underTest = new FileSystemResolver();
         try (Reader reader = underTest.getReader(resources + "/nested_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -32,7 +30,7 @@ public class FileSystemResolverTest {
         File fileRoot = new File(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(fileRoot);
         try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -41,7 +39,7 @@ public class FileSystemResolverTest {
         Path pathRoot = Paths.get(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(pathRoot);
         try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -49,7 +47,7 @@ public class FileSystemResolverTest {
     public void getReaderDefaultRootDoesNotFindFileWithAbsolutePath() throws Exception {
         FileSystemResolver underTest = new FileSystemResolver();
         try (Reader reader = underTest.getReader("/" + resources + "/nested_partials_template.html")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -58,7 +56,7 @@ public class FileSystemResolverTest {
         File fileRoot = new File(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(fileRoot);
         try (Reader reader = underTest.getReader("/absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -67,7 +65,7 @@ public class FileSystemResolverTest {
         Path pathRoot = Paths.get(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(pathRoot);
         try (Reader reader = underTest.getReader("/absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -95,7 +93,7 @@ public class FileSystemResolverTest {
     public void getReaderDefaultRootAndResourceHasDoubleDotRelativePath() throws Exception {
         FileSystemResolver underTest = new FileSystemResolver();
         try (Reader reader = underTest.getReader(resources + "/templates_filepath/../nested_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -104,7 +102,7 @@ public class FileSystemResolverTest {
         File fileRoot = new File(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(fileRoot);
         try (Reader reader = underTest.getReader("absolute/../absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -113,7 +111,7 @@ public class FileSystemResolverTest {
         Path pathRoot = Paths.get(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(pathRoot);
         try (Reader reader = underTest.getReader("absolute/../absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -121,7 +119,7 @@ public class FileSystemResolverTest {
     public void getReaderDefaultRootAndResourceHasDotRelativePath() throws Exception {
         FileSystemResolver underTest = new FileSystemResolver();
         try (Reader reader = underTest.getReader(resources + "/templates_filepath/./absolute_partials_template.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -130,7 +128,7 @@ public class FileSystemResolverTest {
         File fileRoot = new File(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(fileRoot);
         try (Reader reader = underTest.getReader("absolute/./nested_partials_sub.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -139,7 +137,7 @@ public class FileSystemResolverTest {
         Path pathRoot = Paths.get(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(pathRoot);
         try (Reader reader = underTest.getReader("absolute/./nested_partials_sub.html")) {
-            assertThat(reader, is(notNullValue()));
+            assertNotNull(reader);
         }
     }
 
@@ -147,7 +145,7 @@ public class FileSystemResolverTest {
     public void getReaderDefaultRootAndResourceHasInvalidPath() throws Exception {
         FileSystemResolver underTest = new FileSystemResolver();
         try (Reader reader = underTest.getReader("\0")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -156,7 +154,7 @@ public class FileSystemResolverTest {
         File fileRoot = new File(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(fileRoot);
         try (Reader reader = underTest.getReader("\0")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -165,7 +163,7 @@ public class FileSystemResolverTest {
         Path pathRoot = Paths.get(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(pathRoot);
         try (Reader reader = underTest.getReader("\0")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -176,7 +174,7 @@ public class FileSystemResolverTest {
             Path pathRoot = zipFileSystem.getPath("templates");
             FileSystemResolver underTest = new FileSystemResolver(pathRoot);
             try (Reader reader = underTest.getReader("absolute_partials_template.html")) {
-                assertThat(reader, is(notNullValue()));
+                assertNotNull(reader);
             }
         }
     }
@@ -185,7 +183,7 @@ public class FileSystemResolverTest {
     public void getReaderDefaultRootAndResourceIsDirectory() throws Exception {
         FileSystemResolver underTest = new FileSystemResolver();
         try (Reader reader = underTest.getReader(resources + "/templates_filepath")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -194,7 +192,7 @@ public class FileSystemResolverTest {
         File fileRoot = new File(resources);
         FileSystemResolver underTest = new FileSystemResolver(fileRoot);
         try (Reader reader = underTest.getReader("templates_filepath")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -203,7 +201,7 @@ public class FileSystemResolverTest {
         Path pathRoot = Paths.get(resources);
         FileSystemResolver underTest = new FileSystemResolver(pathRoot);
         try (Reader reader = underTest.getReader("templates_filepath")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -214,7 +212,7 @@ public class FileSystemResolverTest {
     public void getReaderDefaultRootAndResourceAboveRootNotFound() throws Exception {
         FileSystemResolver underTest = new FileSystemResolver();
         try (Reader reader = underTest.getReader("../this_file_does_not_exist.html")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -230,7 +228,7 @@ public class FileSystemResolverTest {
         File fileRoot = new File(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(fileRoot);
         try (Reader reader = underTest.getReader("../this_file_does_not_exist.html")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 
@@ -246,7 +244,7 @@ public class FileSystemResolverTest {
         Path pathRoot = Paths.get(resources + "/templates_filepath");
         FileSystemResolver underTest = new FileSystemResolver(pathRoot);
         try (Reader reader = underTest.getReader("../this_file_does_not_exist.html")) {
-            assertThat(reader, is(nullValue()));
+            assertNull(reader);
         }
     }
 }

--- a/compiler/src/test/java/com/github/mustachejava/util/HtmlEscaperTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/util/HtmlEscaperTest.java
@@ -1,13 +1,15 @@
 package com.github.mustachejava.util;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.io.StringWriter;
 
 import static com.github.mustachejava.util.HtmlEscaper.escape;
+import static org.junit.Assert.assertEquals;
 
-public class HtmlEscaperTest extends TestCase {
-  public void testEscape() throws Exception {
+public class HtmlEscaperTest {
+  @Test
+  public void testEscape() {
     {
       StringWriter sw = new StringWriter();
       escape("Hello, world!", sw);

--- a/compiler/src/test/java/com/github/mustachejavabenchmarks/BenchmarkTest.java
+++ b/compiler/src/test/java/com/github/mustachejavabenchmarks/BenchmarkTest.java
@@ -1,7 +1,8 @@
 package com.github.mustachejavabenchmarks;
 
 import com.github.mustachejava.*;
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,21 +16,21 @@ import java.util.concurrent.Executors;
  * Date: 5/14/11
  * Time: 9:28 PM
  */
-public class BenchmarkTest extends TestCase {
+public class BenchmarkTest {
   private static final int TIME = 2000;
   protected File root;
 
-  protected void setUp() throws Exception {
-    super.setUp();
+  @Before
+  public void setUp() throws Exception {
     File file = new File("src/test/resources");
     root = new File(file, "simple.html").exists() ? file : new File("../src/test/resources");
-
   }
 
   public static boolean skip() {
     return System.getenv().containsKey("CI") || System.getProperty("CI") != null;
   }
 
+  @Test
   public void testCompiler() {
     if (skip()) return;
     System.out.println("complex.html compilations per second:");
@@ -48,6 +49,7 @@ public class BenchmarkTest extends TestCase {
     }
   }
 
+  @Test
   public void testComplex() throws MustacheException, IOException {
     if (skip()) return;
     System.out.println("complex.html evaluations per millisecond:");
@@ -73,6 +75,7 @@ public class BenchmarkTest extends TestCase {
     return new DefaultMustacheFactory();
   }
 
+  @Test
   public void testComplexFlapping() throws MustacheException, IOException {
     if (skip()) return;
     System.out.println("complex.html evaluations with 3 different objects per millisecond:");
@@ -96,6 +99,7 @@ public class BenchmarkTest extends TestCase {
     }
   }
 
+  @Test
   public void testParallelComplex() throws MustacheException, IOException {
     if (skip()) return;
     System.out.println("complex.html evaluations per millisecond:");
@@ -117,6 +121,7 @@ public class BenchmarkTest extends TestCase {
     }
   }
 
+  @Test
   public void testParallelComplexNoExecutor() throws MustacheException, IOException {
     if (skip()) return;
     System.out.println("complex.html evaluations per millisecond:");
@@ -142,14 +147,4 @@ public class BenchmarkTest extends TestCase {
     m.execute(sw, complexObject).close();
     return sw;
   }
-
-  public static void main(String[] args) throws Exception {
-    BenchmarkTest benchmarkTest = new BenchmarkTest();
-    benchmarkTest.setUp();
-    benchmarkTest.testComplex();
-    benchmarkTest.testParallelComplex();
-    benchmarkTest.testParallelComplexNoExecutor();
-    System.exit(0);
-  }
-
 }

--- a/compiler/src/test/java/com/github/mustachejavabenchmarks/JsonInterpreterTest.java
+++ b/compiler/src/test/java/com/github/mustachejavabenchmarks/JsonInterpreterTest.java
@@ -6,7 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.github.mustachejavabenchmarks.BenchmarkTest.skip;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the compiler.
@@ -32,7 +34,7 @@ import static com.github.mustachejavabenchmarks.BenchmarkTest.skip;
  * Date: May 3, 2010
  * Time: 10:23:54 AM
  */
-public class JsonInterpreterTest extends TestCase {
+public class JsonInterpreterTest {
   private static final int TIME = 2;
 
   protected File root;
@@ -59,7 +61,8 @@ public class JsonInterpreterTest extends TestCase {
     }
   }
 
-  public void testSingleThreaded() throws MustacheException, IOException, InterruptedException {
+  @Test
+  public void testSingleThreaded() throws MustacheException, IOException {
     if (skip()) return;
     final Mustache parse = getMustache();
     final Object parent = getScope();
@@ -67,7 +70,8 @@ public class JsonInterpreterTest extends TestCase {
     singlethreaded(parse, parent);
   }
 
-  public void testSingleThreadedClass() throws MustacheException, IOException, InterruptedException {
+  @Test
+  public void testSingleThreadedClass() throws MustacheException {
     if (skip()) return;
     final Mustache parse = getMustache();
     final Object parent = new Object() {
@@ -83,6 +87,7 @@ public class JsonInterpreterTest extends TestCase {
     singlethreaded(parse, parent);
   }
 
+  @Test
   public void testContextPrecedence() throws IOException {
     Mustache m = new DefaultMustacheFactory().compile(new StringReader("{{#a}}{{b.c}}{{/a}}"), "test");
     Map map = new ObjectMapper().readValue("{\"a\": {\"b\": {}}, \"b\": {\"c\": \"ERROR\"}}", Map.class);
@@ -92,6 +97,7 @@ public class JsonInterpreterTest extends TestCase {
     assertEquals("", sw.toString());
   }
 
+  @Test
   public void testCompiler() throws MustacheException, IOException, InterruptedException {
     if (skip()) return;
     for (int i = 0; i < 3; i++) {
@@ -113,6 +119,7 @@ public class JsonInterpreterTest extends TestCase {
     return new DefaultMustacheFactory(root);
   }
 
+  @Test
   public void testMultithreaded() throws IOException, InterruptedException {
     if (skip()) return;
     final Mustache parse = getMustache();
@@ -166,7 +173,6 @@ public class JsonInterpreterTest extends TestCase {
   private void singlethreaded(Mustache parse, Object parent) {
     long start = System.currentTimeMillis();
     System.out.println(System.currentTimeMillis() - start);
-    start = System.currentTimeMillis();
     StringWriter writer = new StringWriter();
     parse.execute(writer, parent);
     writer.flush();
@@ -211,11 +217,10 @@ public class JsonInterpreterTest extends TestCase {
     System.out.println((System.currentTimeMillis() - start));
   }
 
-  protected void setUp() throws Exception {
-    super.setUp();
+  @Before
+  public void setUp() throws Exception {
     File file = new File("src/test/resources");
     root = new File(file, "simple.html").exists() ? file : new File("../src/test/resources");
   }
-
 }
 


### PR DESCRIPTION
- Remove usage of jUnit 3.x TestCase
- Introduce use of assertThrows() from jUnit 4.x
- Clean up exception declarations in tests
- Replace hamcrest assertions with jUnit assertions

I considered going straight to v5 but this seemed like a big enough diff

I also converted `BenchmarkTest` to a jUnit test class and removed its `main` method - is that OK?

This also removes all usage of `fail()`, replaced by `assertThrows()`