### PR TITLE
ISSUE-268: Fix ClasspathResolverTest

### DIFF
--- a/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
@@ -106,7 +106,7 @@ public class ClasspathResolverTest {
     public void getReaderNullRootAndResourceIsDirectory() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver();
         try (Reader reader = underTest.getReader("templates/absolute")) {
-            assertThat(reader, is(notNullValue()));
+            assertThat(reader, is(nullValue()));
         }
     }
 
@@ -115,7 +115,7 @@ public class ClasspathResolverTest {
     public void getReaderWithRootAndResourceIsDirectory() throws Exception {
         ClasspathResolver underTest = new ClasspathResolver("templates");
         try (Reader reader = underTest.getReader("absolute")) {
-            assertThat(reader, is(notNullValue()));
+            assertThat(reader, is(nullValue()));
         }
     }
 


### PR DESCRIPTION
Commit efb67c494c79bc0a5da169fe78d2c19a884cd435 changed the behaviour of
ClasspathResolver, breaking the test.

Fix the test to match the intended behaviour of the class.

See https://github.com/spullara/mustache.java/issues/268