### PR TITLE
add manifest information to built jar

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -69,6 +69,10 @@
         </executions>
         <configuration>
           <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+            </manifest>
             <manifestEntries>
               <Automatic-Module-Name>com.github.mustachejava</Automatic-Module-Name>
             </manifestEntries>


### PR DESCRIPTION
This PR adds more information to the `MANIFEST.MF` file inside the built jar, like the version, for example.

The manifest file is consumed by Liquibase to display version information of the included dependencies, and was missing the version:

before:
```
...
- internal\lib\commons-text.jar: Apache Commons Text 1.10.0 By The Apache Software Foundation
- internal\lib\compiler.jar: compiler
- internal\lib\h2.jar: H2 Database Engine 2.1.214 By H2 Group
...
```

after:
```
...
- internal\lib\commons-text.jar: Apache Commons Text 1.10.0 By The Apache Software Foundation
- internal\lib\compiler.jar: compiler 0.9.11-SNAPSHOT
- internal\lib\h2.jar: H2 Database Engine 2.1.214 By H2 Group
...
```