### PR TITLE
Fix ClasspathResolver for non-context class loader case

### DIFF
--- a/compiler/src/main/java/com/github/mustachejava/resolver/ClasspathResolver.java
+++ b/compiler/src/main/java/com/github/mustachejava/resolver/ClasspathResolver.java
@@ -35,7 +35,7 @@ public class ClasspathResolver implements MustacheResolver {
         String normalizeResourceName = URI.create(fullResourceName).normalize().getPath();
 
         URL resource = ccl.getResource(normalizeResourceName);
-        if (resource != null)
+        if (resource != null) {
             if (resource.getProtocol().equals("jar")) {
                 if (normalizeResourceName.endsWith("/")) {
                     // This is a directory
@@ -50,8 +50,10 @@ public class ClasspathResolver implements MustacheResolver {
                     return null;
                 }
             }
-        else
+        } else {
             resource = ClasspathResolver.class.getClassLoader().getResource(normalizeResourceName);
+        }
+
 
         if (resource != null) {
             try {

--- a/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
+++ b/compiler/src/test/java/com/github/mustachejava/resolver/ClasspathResolverTest.java
@@ -3,6 +3,8 @@ package com.github.mustachejava.resolver;
 import org.junit.Test;
 
 import java.io.Reader;
+import java.net.URL;
+import java.net.URLClassLoader;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -123,6 +125,21 @@ public class ClasspathResolverTest {
         ClasspathResolver underTest = new ClasspathResolver("templates/absolute");
         try (Reader reader = underTest.getReader("../absolute_partials_template.html")) {
             assertNotNull(reader);
+        }
+    }
+
+    @Test
+    public void getReaderWithoutContextClassLoader() throws Exception {
+        ClassLoader savedContextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(new URLClassLoader(new URL[]{}, null));
+
+            ClasspathResolver underTest = new ClasspathResolver();
+            try (Reader reader = underTest.getReader("template.mustache")) {
+                assertNotNull(reader);
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(savedContextClassLoader);
         }
     }
 }


### PR DESCRIPTION
Broke the case where the context class loader can't actually find the resource and the fallback has to be used. Also added a test case to catch this specific regression.