### PR TITLE
Add Java module descriptor

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -59,6 +59,36 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.Beta2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <module>
+                <name>com.github.mustachejava</name>
+                <exports>
+                  <package>com.github.mustachejava</package>
+                  <package>com.github.mustachejava.codes</package>
+                  <package>com.github.mustachejava.functions</package>
+                  <package>com.github.mustachejava.reflect</package>
+                  <package>com.github.mustachejava.reflect.guards</package>
+                  <package>com.github.mustachejava.resolver</package>
+                  <package>com.github.mustachejava.util</package>
+                </exports>
+                <requires>
+                  <module>java.base</module>
+                </requires>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
Related to #289

This pull request introduces a full Java module descriptor for the `mustache.java` library by utilizing the ModiTect plugin in the `compiler/pom.xml` file.

- Adds the ModiTect Maven plugin to generate a `module-info.java` file during the package phase.
- Configures the ModiTect plugin to create a module descriptor for `com.github.mustachejava`. This includes specifying the module name, required Java modules, and packages to export.
- Maintains the existing `<Automatic-Module-Name>` manifest entry for backward compatibility.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spullara/mustache.java/issues/289?shareId=0ec743e2-704d-4ff9-82d1-9f2fc2278c2c).